### PR TITLE
Improve Telekit runtime setup, transcription configuration, and operator docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,16 @@
+# Required credentials
 OPENAI_API_KEY=
 API_ID=
 API_HASH=
+
+# Optional runtime defaults
+# Leave these at their defaults unless you know you need to override them.
+
+# Supported target values: whisper-1, gpt-4o-transcribe, gpt-4o-mini-transcribe
+TELEKIT_TRANSCRIPTION_MODEL=whisper-1
+
+# Optional path overrides
+TELEKIT_DATA_DIR=./data
+TELEKIT_CLIENTS_FILE=./data/clients.json
+TELEKIT_SESSIONS_DIR=./data/sessions
+TELEKIT_JOBS_DIR=./jobs

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,12 @@
 .env
 *.session
 /.idea
+/.pytest_cache/
+/.venv/
+__pycache__/
+*.py[cod]
+/build/
+/dist/
+/telekit.egg-info/
+/jobs/
+/.firecrawl/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Run these from the repository root.
 - `uv sync`
 - `uv run telekit --help`
 - `uv run telekit start-program --help`
-- `uv run pytest`
+- `uv run pytest -v`
 - `docker compose build`
 - `docker compose up -d`
 - `docker compose logs --tail=200`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# Telekit Agent Guide
+
+This repository ships a Telegram self-automation client that runs either locally with `uv` or in Docker with `docker compose`. Keep changes small, testable, and aligned with the real operator workflow.
+
+## Working Agreement
+
+- Use `uv` for local Python commands.
+- Prefer repo-relative runtime paths under `data/` and `jobs/`.
+- Never commit `.env`, session files, generated job artifacts, or other private Telegram/OpenAI data.
+- Treat `PLANS.md` as the contract for any substantial feature, refactor, or multi-step recovery. Execution plans live under `docs/exec_plans/active/`.
+
+## Project Orientation
+
+- `app.py` defines the Typer CLI and process entrypoints.
+- `telekit_config.py` resolves environment variables and runtime paths.
+- `control.py` owns Telethon client startup, command routing, and transcript delivery.
+- `commands/ing_transcribe/ing_transcribe.py` is the active user-facing Telegram command.
+- `job_manager/voice_job.py` and `job_manager/transcription_result.py` implement transcription behavior.
+- `docker-compose.yml` and `Dockerfile` define the container workflow.
+
+## Useful Commands
+
+Run these from the repository root.
+
+- `uv sync`
+- `uv run telekit --help`
+- `uv run telekit start-program --help`
+- `uv run pytest`
+- `docker compose build`
+- `docker compose up -d`
+- `docker compose logs --tail=200`
+- `docker compose down`
+
+## Change Discipline
+
+- If a change affects user setup, update `README.md` and `.env.example` in the same pass.
+- If a change affects runtime behavior, add or update tests in `tests/`.
+- If Docker behavior changes, validate with `docker compose` before closing the task.
+- If long-running or risky work is involved, create or update the active ExecPlan before implementation.

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.12-slim
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y \
-    build-essential ffmpeg \
+    --no-install-recommends build-essential ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
 COPY . /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 FROM python:3.12-slim
 
-WORKDIR /app
-
 RUN apt-get update && apt-get install -y \
     --no-install-recommends build-essential ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
-COPY . /app
+RUN useradd --create-home --shell /usr/sbin/nologin --uid 1000 telekit
+
+WORKDIR /app
+
+COPY --chown=telekit:telekit . /app
 
 ENV PYTHONUNBUFFERED=1
 
@@ -14,5 +16,8 @@ RUN pip install --no-cache-dir .
 
 RUN mkdir -p /app/data/sessions /app/jobs
 RUN printf '[]\n' > /app/data/clients.json
+RUN chown -R telekit:telekit /app
+
+USER telekit
 
 CMD ["telekit", "start-program"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,18 @@
-# Use the official image as a parent image
-FROM python:3.9
+FROM python:3.12-slim
 
-# Set work directory
 WORKDIR /app
 
-# Install system dependencies
 RUN apt-get update && apt-get install -y \
-    python3-dev build-essential libssl-dev libffi-dev sqlite3 libsqlite3-dev ffmpeg
+    build-essential ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
 
-# Copy the current directory contents into the container at /app
 COPY . /app
 
-# Create clients.json file with default content
-RUN mkdir -p /app/data/sessions
-RUN touch /app/data/clients.json
+ENV PYTHONUNBUFFERED=1
 
-# Install Python dependencies
-RUN pip install --no-cache-dir -r requirements.txt
-RUN pip install python-dotenv
-RUN pip install pydub
+RUN pip install --no-cache-dir .
 
-# Make port 80 available to the world outside this container
-EXPOSE 80
+RUN mkdir -p /app/data/sessions /app/jobs
+RUN printf '[]\n' > /app/data/clients.json
 
-# Define environment variables
-ENV NAME OPENAI_API_KEY
-ENV NAME API_ID
-ENV NAME API_HASH
-
-# Run app.py when the container launches
-CMD ["sh", "-c", "python app.py start-program & wait"]
+CMD ["telekit", "start-program"]

--- a/PLANS.md
+++ b/PLANS.md
@@ -1,0 +1,150 @@
+# Codex Execution Plans (ExecPlans):
+
+This document describes the requirements for an execution plan ("ExecPlan"), a design document that a coding agent can follow to deliver a working feature or system change. Treat the reader as a complete beginner to this repository: they have only the current working tree and the single ExecPlan file you provide. There is no memory of prior plans and no external context.
+
+## How to use ExecPlans and PLANS.md
+
+When authoring an executable specification (ExecPlan), follow PLANS.md _to the letter_. If it is not in your context, refresh your memory by reading the entire PLANS.md file. Be thorough in reading (and re-reading) source material to produce an accurate specification. When creating a spec, start from the skeleton and flesh it out as you do your research.
+
+When implementing an executable specification (ExecPlan), do not prompt the user for "next steps"; simply proceed to the next milestone. Keep all sections up to date, add or split entries in the list at every stopping point to affirmatively state the progress made and next steps. Resolve ambiguities autonomously, and commit frequently.
+
+When discussing an executable specification (ExecPlan), record decisions in a log in the spec for posterity; it should be unambiguously clear why any change to the specification was made. ExecPlans are living documents, and it should always be possible to restart from _only_ the ExecPlan and no other work.
+
+When researching a design with challenging requirements or significant unknowns, use milestones to implement proof of concepts, "toy implementations", etc., that allow validating whether the user's proposal is feasible. Read the source code of libraries by finding or acquiring them, research deeply, and include prototypes to guide a fuller implementation.
+
+## Requirements
+
+NON-NEGOTIABLE REQUIREMENTS:
+
+- Every ExecPlan must be fully self-contained. Self-contained means that in its current form it contains all knowledge and instructions needed for a novice to succeed.
+- Every ExecPlan is a living document. Contributors are required to revise it as progress is made, as discoveries occur, and as design decisions are finalized. Each revision must remain fully self-contained.
+- Every ExecPlan must enable a complete novice to implement the feature end-to-end without prior knowledge of this repo.
+- Every ExecPlan must produce a demonstrably working behavior, not merely code changes to "meet a definition".
+- Every ExecPlan must define every term of art in plain language or do not use it.
+
+Purpose and intent come first. Begin by explaining, in a few sentences, why the work matters from a user's perspective: what someone can do after this change that they could not do before, and how to see it working. Then guide the reader through the exact steps to achieve that outcome, including what to edit, what to run, and what they should observe.
+
+The agent executing your plan can list files, read files, search, run the project, and run tests. It does not know any prior context and cannot infer what you meant from earlier milestones. Repeat any assumption you rely on. Do not point to external blogs or docs; if knowledge is required, embed it in the plan itself in your own words. If an ExecPlan builds upon a prior ExecPlan and that file is checked in, incorporate it by reference. If it is not, you must include all relevant context from that plan.
+
+## Formatting
+
+Format and envelope are simple and strict. Each ExecPlan must be one single fenced code block labeled as `md` that begins and ends with triple backticks. Do not nest additional triple-backtick code fences inside; when you need to show commands, transcripts, diffs, or code, present them as indented blocks within that single fence. Use indentation for clarity rather than code fences inside an ExecPlan to avoid prematurely closing the ExecPlan's code fence. Use two newlines after every heading, use # and ## and so on, and correct syntax for ordered and unordered lists.
+
+When writing an ExecPlan to a Markdown (.md) file where the content of the file _is only_ the single ExecPlan, you should omit the triple backticks.
+
+Write in plain prose. Prefer sentences over lists. Avoid checklists, tables, and long enumerations unless brevity would obscure meaning. Checklists are permitted only in the `Progress` section, where they are mandatory. Narrative sections must remain prose-first.
+
+## Guidelines
+
+Self-containment and plain language are paramount. If you introduce a phrase that is not ordinary English ("daemon", "middleware", "RPC gateway", "filter graph"), define it immediately and remind the reader how it manifests in this repository (for example, by naming the files or commands where it appears). Do not say "as defined previously" or "according to the architecture doc." Include the needed explanation here, even if you repeat yourself.
+
+Avoid common failure modes. Do not rely on undefined jargon. Do not describe "the letter of a feature" so narrowly that the resulting code compiles but does nothing meaningful. Do not outsource key decisions to the reader. When ambiguity exists, resolve it in the plan itself and explain why you chose that path. Err on the side of over-explaining user-visible effects and under-specifying incidental implementation details.
+
+Anchor the plan with observable outcomes. State what the user can do after implementation, the commands to run, and the outputs they should see. Acceptance should be phrased as behavior a human can verify ("after starting the server, navigating to [http://localhost:8080/health](http://localhost:8080/health) returns HTTP 200 with body OK") rather than internal attributes ("added a HealthCheck struct"). If a change is internal, explain how its impact can still be demonstrated (for example, by running tests that fail before and pass after, and by showing a scenario that uses the new behavior).
+
+Specify repository context explicitly. Name files with full repository-relative paths, name functions and modules precisely, and describe where new files should be created. If touching multiple areas, include a short orientation paragraph that explains how those parts fit together so a novice can navigate confidently. When running commands, show the working directory and exact command line. When outcomes depend on environment, state the assumptions and provide alternatives when reasonable.
+
+Be idempotent and safe. Write the steps so they can be run multiple times without causing damage or drift. If a step can fail halfway, include how to retry or adapt. If a migration or destructive operation is necessary, spell out backups or safe fallbacks. Prefer additive, testable changes that can be validated as you go.
+
+Validation is not optional. Include instructions to run tests, to start the system if applicable, and to observe it doing something useful. Describe comprehensive testing for any new features or capabilities. Include expected outputs and error messages so a novice can tell success from failure. Where possible, show how to prove that the change is effective beyond compilation (for example, through a small end-to-end scenario, a CLI invocation, or an HTTP request/response transcript). State the exact test commands appropriate to the project’s toolchain and how to interpret their results.
+
+Capture evidence. When your steps produce terminal output, short diffs, or logs, include them inside the single fenced block as indented examples. Keep them concise and focused on what proves success. If you need to include a patch, prefer file-scoped diffs or small excerpts that a reader can recreate by following your instructions rather than pasting large blobs.
+
+## Milestones
+
+Milestones are narrative, not bureaucracy. If you break the work into milestones, introduce each with a brief paragraph that describes the scope, what will exist at the end of the milestone that did not exist before, the commands to run, and the acceptance you expect to observe. Keep it readable as a story: goal, work, result, proof. Progress and milestones are distinct: milestones tell the story, progress tracks granular work. Both must exist. Never abbreviate a milestone merely for the sake of brevity, do not leave out details that could be crucial to a future implementation.
+
+Each milestone must be independently verifiable and incrementally implement the overall goal of the execution plan.
+
+## Living plans and design decisions
+
+- ExecPlans are living documents. As you make key design decisions, update the plan to record both the decision and the thinking behind it. Record all decisions in the `Decision Log` section.
+- ExecPlans must contain and maintain a `Progress` section, a `Surprises & Discoveries` section, a `Decision Log`, and an `Outcomes & Retrospective` section. These are not optional.
+- When you discover optimizer behavior, performance tradeoffs, unexpected bugs, or inverse/unapply semantics that shaped your approach, capture those observations in the `Surprises & Discoveries` section with short evidence snippets (test output is ideal).
+- If you change course mid-implementation, document why in the `Decision Log` and reflect the implications in `Progress`. Plans are guides for the next contributor as much as checklists for you.
+- At completion of a major task or the full plan, write an `Outcomes & Retrospective` entry summarizing what was achieved, what remains, and lessons learned.
+
+# Prototyping milestones and parallel implementations
+
+It is acceptable—-and often encouraged—-to include explicit prototyping milestones when they de-risk a larger change. Examples: adding a low-level operator to a dependency to validate feasibility, or exploring two composition orders while measuring optimizer effects. Keep prototypes additive and testable. Clearly label the scope as “prototyping”; describe how to run and observe results; and state the criteria for promoting or discarding the prototype.
+
+Prefer additive code changes followed by subtractions that keep tests passing. Parallel implementations (e.g., keeping an adapter alongside an older path during migration) are fine when they reduce risk or enable tests to continue passing during a large migration. Describe how to validate both paths and how to retire one safely with tests. When working with multiple new libraries or feature areas, consider creating spikes that evaluate the feasibility of these features _independently_ of one another, proving that the external library performs as expected and implements the features we need in isolation.
+
+## Skeleton of a Good ExecPlan
+
+    # <Short, action-oriented description>
+
+    This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+    If PLANS.md file is checked into the repo, reference the path to that file here from the repository root and note that this document must be maintained in accordance with PLANS.md.
+
+    ## Purpose / Big Picture
+
+    Explain in a few sentences what someone gains after this change and how they can see it working. State the user-visible behavior you will enable.
+
+    ## Progress
+
+    Use a list with checkboxes to summarize granular steps. Every stopping point must be documented here, even if it requires splitting a partially completed task into two (“done” vs. “remaining”). This section must always reflect the actual current state of the work.
+
+    - [x] (2025-10-01 13:00Z) Example completed step.
+    - [ ] Example incomplete step.
+    - [ ] Example partially completed step (completed: X; remaining: Y).
+
+    Use timestamps to measure rates of progress.
+
+    ## Surprises & Discoveries
+
+    Document unexpected behaviors, bugs, optimizations, or insights discovered during implementation. Provide concise evidence.
+
+    - Observation: …
+      Evidence: …
+
+    ## Decision Log
+
+    Record every decision made while working on the plan in the format:
+
+    - Decision: …
+      Rationale: …
+      Date/Author: …
+
+    ## Outcomes & Retrospective
+
+    Summarize outcomes, gaps, and lessons learned at major milestones or at completion. Compare the result against the original purpose.
+
+    ## Context and Orientation
+
+    Describe the current state relevant to this task as if the reader knows nothing. Name the key files and modules by full path. Define any non-obvious term you will use. Do not refer to prior plans.
+
+    ## Plan of Work
+
+    Describe, in prose, the sequence of edits and additions. For each edit, name the file and location (function, module) and what to insert or change. Keep it concrete and minimal.
+
+    ## Concrete Steps
+
+    State the exact commands to run and where to run them (working directory). When a command generates output, show a short expected transcript so the reader can compare. This section must be updated as work proceeds.
+
+    ## Validation and Acceptance
+
+    Describe how to start or exercise the system and what to observe. Phrase acceptance as behavior, with specific inputs and outputs. If tests are involved, say "run <project’s test command> and expect <N> passed; the new test <name> fails before the change and passes after>".
+
+    ## Idempotence and Recovery
+
+    If steps can be repeated safely, say so. If a step is risky, provide a safe retry or rollback path. Keep the environment clean after completion.
+
+    ## Artifacts and Notes
+
+    Include the most important transcripts, diffs, or snippets as indented examples. Keep them concise and focused on what proves success.
+
+    ## Interfaces and Dependencies
+
+    Be prescriptive. Name the libraries, modules, and services to use and why. Specify the types, traits/interfaces, and function signatures that must exist at the end of the milestone. Prefer stable names and paths such as `crate::module::function` or `package.submodule.Interface`. E.g.:
+
+    In crates/foo/planner.rs, define:
+
+        pub trait Planner {
+            fn plan(&self, observed: &Observed) -> Vec<Action>;
+        }
+
+If you follow the guidance above, a single, stateless agent -- or a human novice -- can read your ExecPlan from top to bottom and produce a working, observable result. That is the bar: SELF-CONTAINED, SELF-SUFFICIENT, NOVICE-GUIDING, OUTCOME-FOCUSED.
+
+When you revise a plan, you must ensure your changes are comprehensively reflected across all sections, including the living document sections, and you must write a note at the bottom of the plan describing the change and the reason why. ExecPlans must describe not just the what but the why for almost everything.

--- a/README.md
+++ b/README.md
@@ -1,106 +1,280 @@
-## Telekit
+# Telekit
 
-A Telegram automation client built with Python's Telethon library. Currently supports:
+Telekit is a Telegram self-automation client built with Telethon. It signs into your own Telegram account, watches your outgoing messages, and transcribes voice notes with OpenAI speech-to-text models.
 
-1. Automatically transcribing your own voice messages.
-2. Using shortcut to transcribe other people's voice messages.
+This is not a Telegram bot account with a `/start` command or a web app. Telekit runs as your own Telegram client session.
 
-### Table of Contents
+## What Telekit Can Do Today
 
-- [Installation](#installation)
-- [Usage](#usage)
-- [Features](#features)
-- [Contributing](#contributing)
+- Automatically transcribe voice messages that you send from your own Telegram account.
+- Transcribe someone else's voice message when you reply to it with `@` or `@ingTranscribe`.
+- Return the result as inline text or as a text file, depending on the command flags and Telegram message limits.
+- Run multiple Telegram sessions from one Telekit install.
 
-### Installation
+## What Is Planned or In Progress
 
-#### Prerequisites
+- Real VTT output instead of the current plain-text fallback.
+- Real summarization and chapter generation for reply-trigger mode.
+- A real GPT command surface to replace the current stub.
+- Migration from the legacy OpenAI Python client to the current SDK.
 
-- Python 3.x
-- pip
-- Telegram account
-- OpenAI account
-- Telegram API ID and hash: https://core.telegram.org/api/obtaining_api_id
+## Current Limitations
 
-#### Steps
+- `IngGPTCommand` exists in the codebase but is not implemented yet.
+- `--summarize` and `--chapters` flags are parsed by the transcription command but do not currently change behavior.
+- `--format vtt` is not fully implemented. The current code falls back to sending a text file.
+- The current code listens to outgoing messages only. That is intentional for a self-automation client, but it means Telekit does not act like a separate Telegram bot account.
+- Python 3.13 is not supported by the current Telethon stack used in this repository. Use Python 3.10 through 3.12.
 
-1. Clone the repository:
-   ```bash
-   git clone https://github.com/doomuch/telekit telekit
-   ```
-2. Navigate to the project directory:
-   ```bash
-   cd telekit
-   ```
-3. Install the dependencies:
-   ```bash
-   pip install -r requirements.txt
-   ```
-4. Copy an `.env` file and add your keys there:
-   ```bash
-   cp .env.example .env
-   ```
+## Quick Start
 
-### Usage
+Choose one installation path:
 
-#### From Commandline
+- Docker operator path: best if you want the simplest deployment and do not want to manage Python directly.
+- Local developer path: best if you want to work on the code, inspect logs, or run Telekit without Docker.
 
-To add a client with a specific session name:
+## Prerequisites
+
+You need all of the following regardless of installation path:
+
+- A Telegram account.
+- A Telegram API ID and API hash from <https://core.telegram.org/api/obtaining_api_id>.
+- An OpenAI API key.
+
+You should also know that Telekit stores Telegram session files on disk. Those files let Telekit sign back into your account without asking for login information every time.
+
+## Configuration
+
+Copy the example file first:
 
 ```bash
+cp .env.example .env
+```
+
+Then fill in the required values:
+
+- `OPENAI_API_KEY`: your OpenAI API key.
+- `API_ID`: your Telegram API ID.
+- `API_HASH`: your Telegram API hash.
+
+The current runtime also supports these optional settings:
+
+- `TELEKIT_TRANSCRIPTION_MODEL`: default transcription model. Planned supported values are `whisper-1`, `gpt-4o-transcribe`, and `gpt-4o-mini-transcribe`.
+- `TELEKIT_DATA_DIR`: override the base runtime data directory.
+- `TELEKIT_CLIENTS_FILE`: override the path to `clients.json`.
+- `TELEKIT_SESSIONS_DIR`: override where Telegram session files are stored.
+- `TELEKIT_JOBS_DIR`: override where temporary audio job files are stored.
+
+For compatibility, Telekit also accepts the older singular alias `TELEKIT_SESSION_DIR`, but `TELEKIT_SESSIONS_DIR` is the preferred name.
+
+If you do not need to change model or path behavior, leave the `TELEKIT_*` values at their defaults.
+
+## Local Developer Workflow
+
+The supported local flow is:
+
+```bash
+uv sync
+uv run telekit --help
+```
+
+The legacy entrypoint still works inside the synced environment:
+
+```bash
+python app.py --help
 python app.py add-client my_session
-```
-
-To delete a client:
-
-```bash
-python app.py delete-client
-```
-
-To start the program:
-
-```bash
 python app.py start-program
 ```
 
-#### From Docker
+If you are contributing to the codebase, prefer the `uv` path. `python app.py ...` is kept as a compatibility entrypoint, but it still depends on having the project environment installed first.
 
-Build docker image:
+## Docker Operator Workflow
 
-```bash
-sudo docker build -t telekit .
-```
-
-To run docker container:
+Build the image:
 
 ```bash
-sudo docker run -d -p 4000:80 --env-file .env -v ./data:/app/data -v ./data/sessions:/app/data/sessions --name telekit telekit
+docker build -t telekit .
 ```
 
-It runs `start-program` command on startup so if you already has a session, you don't need to run `start-program` again.
-
-To init a new session (replace {SESSION_NAME} with your session name):
+Run the container with your `.env` file and persistent session storage:
 
 ```bash
-sudo docker exec telekit python /app/app.py add-client {SESSION_NAME}
+docker run -d \
+  --env-file .env \
+  -v "$(pwd)/data:/app/data" \
+  -v "$(pwd)/data/sessions:/app/data/sessions" \
+  --name telekit \
+  telekit
 ```
 
-After that you need to run `start-program` and proceed Telegram authentication:
+Create a Telegram session inside the container:
 
 ```bash
-sudo docker exec -it telekit python /app/app.py start-program
+docker exec -it telekit python /app/app.py add-client my_session
+docker exec -it telekit python /app/app.py start-program
 ```
 
-After entering the necessary information interactively, you can exit the interactive session without stopping the Python script by pressing `Ctrl + P` or `Ctrl + Q`. This key combination detaches from the container without terminating the running process.
+During the first login, Telekit will ask for Telegram authentication details in the terminal. After the session file is created, Telekit can reuse it on later starts.
 
-### Features
+Note: Telekit does not currently expose an HTTP interface. If you see old examples with published ports, treat those as legacy deployment leftovers rather than a required part of setup.
 
-- Transcribes voice messages.
-- Handles multiple clients.
-- Supports various output formats.
+## CLI Help
 
-### Contributing
+Once dependencies are installed, you can see the available commands with:
 
-If you'd like to contribute, please fork the repository and make changes as you'd like. Pull requests are warmly welcome.
+```bash
+python app.py --help
+python app.py add-client --help
+python app.py delete-client --help
+python app.py start-program --help
+```
 
-This project is in early development stage, so there are many things to be done. Feel free to open an issue to discuss what you would like to change.
+The packaged console script is:
+
+```bash
+telekit --help
+telekit add-client --help
+telekit delete-client --help
+telekit start-program --help
+```
+
+## How To Use Telekit In Telegram
+
+Telekit responds to actions from your own Telegram account.
+
+### 1. Automatic transcription of your own voice notes
+
+Send a voice note from the Telegram account that Telekit is signed into. Telekit will detect that outgoing voice message and replace it with a transcription result.
+
+### 2. Transcribe someone else's voice note
+
+Reply to the voice note with one of these triggers:
+
+- `@`
+- `@ingTranscribe`
+
+Example:
+
+```text
+@
+```
+
+or
+
+```text
+@ingTranscribe
+```
+
+Telekit will fetch the replied-to voice note and send back the transcript.
+
+## Transcription Flags
+
+The current transcription command recognizes these flags in reply-trigger mode:
+
+- `-f`, `--format`: choose output format. Today the practical values are `text` and `file`.
+- `-m`, `--model`: override the transcription model for this command. Supported values are `whisper-1`, `gpt-4o-transcribe`, and `gpt-4o-mini-transcribe`.
+- `-n`, `--new`: send a new reply instead of editing the existing target when possible.
+- `-e`, `--existing`: prefer editing the existing target when possible.
+- `-s`, `--summarize`: accepted by the parser, but not implemented yet.
+- `-c`, `--chapters`: accepted by the parser, but not implemented yet.
+
+Example:
+
+```text
+@ --format file
+```
+
+Example with the long form:
+
+```text
+@ingTranscribe --format text
+```
+
+Important behavior notes:
+
+- If the transcript is small enough, Telekit tries to return text inline.
+- If the transcript is too large for one Telegram message, Telekit now splits it across multiple inline messages before falling back to `transcription.txt`.
+- For voice messages with media captions, Telekit edits the original caption to a short continuation notice and posts the full transcript as text replies when necessary.
+
+## Model Selection
+
+Telekit supports these transcription models today:
+
+- `whisper-1`
+- `gpt-4o-transcribe`
+- `gpt-4o-mini-transcribe`
+
+The default is `whisper-1`. You can change it in either of these ways:
+
+- environment variable: `TELEKIT_TRANSCRIPTION_MODEL=gpt-4o-mini-transcribe`
+- process flag: `telekit start-program --transcription-model gpt-4o-transcribe`
+- reply-trigger override: `@ --model gpt-4o-mini-transcribe`
+
+The reason model selection needs validation instead of a simple string swap is that model outputs differ:
+
+- `whisper-1` supports timestamp-oriented outputs such as `verbose_json`, `srt`, and `vtt`.
+- The GPT transcription models use plain `json` or `text` style responses rather than Whisper timestamp segments.
+
+Telekit normalizes those response shapes internally. If you choose a model that does not support a requested output format, Telekit replies with a plain-language fallback message instead of silently doing the wrong thing.
+
+## Capability Summary
+
+Implemented now:
+
+- automatic transcription of your own outgoing voice messages
+- reply-based transcription with `@` or `@ingTranscribe`
+- multiple client sessions
+- inline text output when short enough
+- inline chunked text output when transcripts exceed a single Telegram message
+- long-audio chunking through temporary exported audio files
+- configurable model selection through env, process flags, and reply-trigger flags
+- text-file fallback when needed
+
+Not implemented yet or incomplete:
+
+- GPT assistant command behavior
+- real summarization mode
+- real chapter generation
+- fully supported VTT output
+
+## Troubleshooting
+
+### `python app.py --help` fails before it prints help
+
+This usually means you are using the system interpreter without the project environment installed. The supported local path is:
+
+```bash
+uv sync
+uv run telekit --help
+```
+
+### Telekit asks for Telegram login every time
+
+That usually means your session directory is not being persisted. Make sure the session files are stored in a persistent `data/sessions` directory or the container volume that maps to it.
+
+### A long transcript becomes `transcription.txt`
+
+That now happens only when you explicitly ask for file output or when Telegram/API constraints still prevent usable inline text. Normal long transcripts should be split into multiple inline messages first.
+
+### You expected Telekit to behave like a separate bot
+
+Telekit is a self-automation client, not a standalone Telegram bot account. It reacts to your own account session.
+
+## Development Notes
+
+Important files if you are working on Telekit itself:
+
+- `app.py`: Typer CLI entrypoint.
+- `control.py`: Telethon client setup and Telegram message sending/editing behavior.
+- `commands/ing_transcribe/ing_transcribe.py`: Telegram transcription trigger and flags.
+- `job_manager/voice_job.py`: audio transcription workflow.
+- `job_manager/transcription_result.py`: transcript result parsing.
+- `utils.py`: audio conversion and audio splitting helpers.
+
+The current implementation roadmap is tracked in:
+
+- `docs/exec_plans/active/2026-03-07-telekit-runtime-transcription-execplan.md`
+
+## Contributing
+
+Pull requests are welcome. If you plan to work on runtime, model support, or packaging changes, read the active ExecPlan first so your changes stay aligned with the repository migration now in progress.

--- a/README.md
+++ b/README.md
@@ -43,12 +43,48 @@ You need all of the following regardless of installation path:
 
 You should also know that Telekit stores Telegram session files on disk. Those files let Telekit sign back into your account without asking for login information every time.
 
+## Beginner Setup
+
+If you do not already have a Python development environment, start here before running any Telekit commands.
+
+### Windows
+
+1. Install Python 3.12 from <https://www.python.org/downloads/windows/> and make sure the installer option to add Python to `PATH` is enabled.
+2. Install Git from <https://git-scm.com/download/win> if you want to clone the repository. If not, download the project ZIP from GitHub and extract it.
+3. Open `PowerShell` in the Telekit folder.
+
+### macOS
+
+1. Install Python 3.12 from <https://www.python.org/downloads/macos/> or with Homebrew.
+2. Install Git with Xcode Command Line Tools: `xcode-select --install`, or download the project ZIP from GitHub if you do not want to use Git.
+3. Open `Terminal` in the Telekit folder.
+
+### Linux
+
+1. Install Python 3.12 and Git with your package manager, or download the project ZIP from GitHub and extract it manually.
+2. Open your terminal in the Telekit folder.
+
+### If you do not want to use Git
+
+You can still run Telekit:
+
+1. Open the GitHub repository page.
+2. Download the project as a ZIP archive.
+3. Extract it to a folder you control.
+4. Open a terminal in that extracted folder before running the commands below.
+
 ## Configuration
 
 Copy the example file first:
 
 ```bash
 cp .env.example .env
+```
+
+On Windows PowerShell, use:
+
+```powershell
+Copy-Item .env.example .env
 ```
 
 Then fill in the required values:
@@ -59,7 +95,7 @@ Then fill in the required values:
 
 The current runtime also supports these optional settings:
 
-- `TELEKIT_TRANSCRIPTION_MODEL`: default transcription model. Planned supported values are `whisper-1`, `gpt-4o-transcribe`, and `gpt-4o-mini-transcribe`.
+- `TELEKIT_TRANSCRIPTION_MODEL`: default transcription model. Supported values are `whisper-1`, `gpt-4o-transcribe`, and `gpt-4o-mini-transcribe`.
 - `TELEKIT_DATA_DIR`: override the base runtime data directory.
 - `TELEKIT_CLIENTS_FILE`: override the path to `clients.json`.
 - `TELEKIT_SESSIONS_DIR`: override where Telegram session files are stored.
@@ -69,6 +105,13 @@ For compatibility, Telekit also accepts the older singular alias `TELEKIT_SESSIO
 
 If you do not need to change model or path behavior, leave the `TELEKIT_*` values at their defaults.
 
+### Safe `.env` editing
+
+- Edit `.env` with a plain text editor such as VS Code, TextEdit in plain-text mode, Notepad, or nano.
+- Do not commit `.env` to Git. It contains secrets.
+- Keep the values on one line each in `KEY=value` format.
+- If you copy the file to a server, restrict access to the account that runs Telekit.
+
 ## Local Developer Workflow
 
 The supported local flow is:
@@ -77,6 +120,14 @@ The supported local flow is:
 uv sync
 uv run telekit --help
 ```
+
+If `uv` is not installed yet, install it first:
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+On Windows, see <https://docs.astral.sh/uv/getting-started/installation/>.
 
 The legacy entrypoint still works inside the synced environment:
 
@@ -117,6 +168,19 @@ docker exec -it telekit python /app/app.py start-program
 During the first login, Telekit will ask for Telegram authentication details in the terminal. After the session file is created, Telekit can reuse it on later starts.
 
 Note: Telekit does not currently expose an HTTP interface. If you see old examples with published ports, treat those as legacy deployment leftovers rather than a required part of setup.
+
+## Beginner Troubleshooting
+
+- `uv: command not found`
+  Install `uv` first, then restart your shell.
+- `python: command not found` or `python3: command not found`
+  Python is not installed correctly or is not on your shell `PATH`. Reinstall Python 3.10 through 3.12 and reopen the terminal.
+- `Configuration error: API_ID`
+  Your `.env` file is missing one or more required credentials.
+- Telekit asks for phone and login code every time
+  Your session file was not saved in `data/sessions`, or the session is not authorized yet.
+- `ModuleNotFoundError`
+  You likely skipped `uv sync` or are using `python app.py ...` outside the project environment.
 
 ## CLI Help
 

--- a/app.py
+++ b/app.py
@@ -15,6 +15,7 @@ from telekit_config import (
     SUPPORTED_TRANSCRIPTION_MODELS,
     ensure_runtime_paths,
     load_settings,
+    validate_session_name,
     validate_startup_settings,
 )
 
@@ -34,8 +35,16 @@ def load_client_data(*, root_dir: Path | None = None) -> tuple[list[dict], objec
     with settings.clients_file.open("r", encoding="utf-8") as handle:
         try:
             data = json.load(handle)
-        except json.JSONDecodeError:
-            data = []
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"Malformed client registry: {settings.clients_file}. "
+                "Fix or replace the file before continuing."
+            ) from exc
+    if not isinstance(data, list):
+        raise ValueError(
+            f"Malformed client registry: {settings.clients_file}. "
+            "Expected a JSON list of client definitions."
+        )
     return data, settings
 
 
@@ -57,6 +66,10 @@ def add_client(session: str):
     Register a Telegram session name inside data/clients.json.
     """
     client_data, settings = load_client_data()
+    session = validate_session_name(session)
+    if any(client.get("session_name") == session for client in client_data):
+        typer.echo(f"Session '{session}' is already registered.", err=True)
+        raise typer.Exit(code=2)
     new_client = default_client_config(session)
     client_data.append(new_client)
     save_client_data(client_data, settings=settings)

--- a/app.py
+++ b/app.py
@@ -1,99 +1,117 @@
-# this bot is inteded to transcribe all voice and video messages sent by user, using telethon
-import json
-import os
+from __future__ import annotations
+
 import asyncio
-from dotenv import load_dotenv
-
-load_dotenv()
-api_key = os.getenv('API_ID')
-api_hash = os.getenv('API_HASH')
-
-
+import json
 import logging
+from pathlib import Path
+from typing import Optional
 
 logging.basicConfig(level=logging.INFO)
 
-from commands import IngTranscribeCommand, IngGPTCommand
-
-from control import ClientHandler, ClientFactory
 import typer
+from control import ClientFactory
+from telekit_config import (
+    DEFAULT_COMMANDS,
+    SUPPORTED_TRANSCRIPTION_MODELS,
+    ensure_runtime_paths,
+    load_settings,
+    validate_startup_settings,
+)
 
-app = typer.Typer()
+app = typer.Typer(
+    help=(
+        "Telekit is a Telegram self-automation client. It runs under your own "
+        "Telegram account, watches outgoing messages, and can transcribe voice "
+        "notes using the configured OpenAI transcription model."
+    ),
+    no_args_is_help=True,
+)
 
-# Ensure the 'data' directory exists
-data_dir = 'data'
-os.makedirs(data_dir, exist_ok=True)
-clients_file_path = os.path.join(data_dir, 'clients.json') # path/to/clients.json
 
-if not os.path.exists(clients_file_path):
-    with open(clients_file_path, 'w') as f:
-        json.dump([], f)
-else:
-    with open(clients_file_path, 'r') as f:
+def load_client_data(*, root_dir: Path | None = None) -> tuple[list[dict], object]:
+    settings = load_settings(root_dir=root_dir)
+    ensure_runtime_paths(settings)
+    with settings.clients_file.open("r", encoding="utf-8") as handle:
         try:
-            client_data = json.load(f)
+            data = json.load(handle)
         except json.JSONDecodeError:
-            client_data = []
+            data = []
+    return data, settings
+
+
+def save_client_data(client_data: list[dict], *, settings) -> None:
+    with settings.clients_file.open("w", encoding="utf-8") as handle:
+        json.dump(client_data, handle, indent=4)
+
+
+def default_client_config(session: str) -> dict:
+    return {
+        "session_name": session,
+        "commands": list(DEFAULT_COMMANDS),
+    }
 
 
 @app.command()
 def add_client(session: str):
     """
-    Add a client to the client data based on user input for a session name. The commands will be standard.
-
-    :param session: str The session name for the new client.
-    :return: None
+    Register a Telegram session name inside data/clients.json.
     """
-    new_client = {
-            "session_name": session,
-            "commands": ["IngTranscribeCommand", "IngGPTCommand"]
-        }
+    client_data, settings = load_client_data()
+    new_client = default_client_config(session)
     client_data.append(new_client)
-    # save json
-    with open(clients_file_path, 'w') as f:
-        json.dump(client_data, f, indent=4)
-
+    save_client_data(client_data, settings=settings)
     print(f"Added new client with session name: {session}")
+
 
 @app.command()
 def delete_client():
+    """Remove a previously registered Telegram session."""
+    client_data, settings = load_client_data()
     print("Here are the available clients:")
     for index, client in enumerate(client_data, start=1):
         print(f"{index}. {client['session_name']}")
 
     session = typer.prompt("Please enter the session name of the client you want to delete")
     client_data[:] = [client for client in client_data if client.get("session_name") != session]
-    print(client_data)
-
-    with open(clients_file_path, 'w') as f:
-        json.dump(client_data, f, indent=4)
+    save_client_data(client_data, settings=settings)
     print(f"Deleted client with session name: {session}")
 
 
 @app.command()
-def start_program():
+def start_program(
+    transcription_model: Optional[str] = typer.Option(
+        None,
+        "--transcription-model",
+        help=(
+            "Default transcription model for this process. Supported values: "
+            + ", ".join(SUPPORTED_TRANSCRIPTION_MODELS)
+        ),
+    ),
+):
     """
-    Starts the main program after updating the client_data with added and/or deleted clients
-    :return: None
+    Start the long-running Telethon client process.
     """
-    loop = asyncio.get_event_loop()
+    settings = load_settings(transcription_model=transcription_model)
+    ensure_runtime_paths(settings)
+    validation_errors = validate_startup_settings(settings)
+    if validation_errors:
+        for error in validation_errors:
+            typer.echo(f"Configuration error: {error}", err=True)
+        raise typer.Exit(code=2)
 
     try:
-        # Schedule the main coroutine and the do_nothing coroutine
-        asyncio.ensure_future(main())
-        asyncio.ensure_future(do_nothing())
-
-        loop.run_forever()
+        asyncio.run(main(settings))
     except KeyboardInterrupt:
-        loop.stop()
+        typer.echo("Telekit stopped.")
 
 
-async def main():
-    client_handlers = {}
+async def main(settings) -> None:
+    client_data, _ = load_client_data(root_dir=settings.root_dir)
     for config in client_data:
-        client = ClientFactory.create_client(config)
+        client = ClientFactory.create_client(config, settings=settings)
         await client.start()
     print("bot started")
+    await do_nothing()
 
 
 async def do_nothing():
@@ -103,4 +121,3 @@ async def do_nothing():
 
 if __name__ == "__main__":
     app()
-

--- a/commands/__init__.py
+++ b/commands/__init__.py
@@ -1,5 +1,11 @@
-# commands/__init__.py
+from importlib import import_module
 
-from commands.ing_transcribe import IngTranscribeCommand
-from .ing_gpt import IngGPTCommand
+__all__ = ["IngGPTCommand", "IngTranscribeCommand"]
 
+
+def __getattr__(name):
+    if name == "IngGPTCommand":
+        return import_module("commands.ing_gpt").IngGPTCommand
+    if name == "IngTranscribeCommand":
+        return import_module("commands.ing_transcribe.ing_transcribe").IngTranscribeCommand
+    raise AttributeError(name)

--- a/commands/ing_transcribe/ing_transcribe.py
+++ b/commands/ing_transcribe/ing_transcribe.py
@@ -146,7 +146,14 @@ class IngTranscribeCommand(Command):
             if arg in ("-f", "--format") and i + 1 < len(args):
                 self.format = args[i + 1]
             elif arg in ("-m", "--model") and i + 1 < len(args):
-                self.model = args[i + 1]
+                requested_model = args[i + 1]
+                self.model = VoiceJob.resolve_model(requested_model)
+                if self.model != requested_model:
+                    logging.warning(
+                        "Unsupported transcription model %s requested. Falling back to %s.",
+                        requested_model,
+                        self.model,
+                    )
             elif arg in ("-s", "--summarize"):
                 self.summarize = True
             elif arg in ("-c", "--chapters"):

--- a/commands/ing_transcribe/ing_transcribe.py
+++ b/commands/ing_transcribe/ing_transcribe.py
@@ -1,8 +1,9 @@
+import datetime
 import logging
 
-from commands.base import Command
-import datetime
 from telethon.tl.types import Message
+
+from commands.base import Command
 from job_manager.voice_job import VoiceJob
 
 
@@ -10,6 +11,7 @@ class IngTranscribeCommand(Command):
     """
     This command transcribes a voice message or a reply to a message.
     """
+
     command_name = "@ingTranscribe"
     aliases = ["@"]
 
@@ -17,22 +19,20 @@ class IngTranscribeCommand(Command):
         super().__init__(event, client_handler)
         self.peer_id = self.event.message.peer_id
 
-        self.format = "text"  # Default format
+        self.format = "text"
+        self.model = None
         self.summarize = False
         self.create_chapters = False
         self._edit_existing = True
         self._send_as_new = None
-        self._prepend_message = True if not self.is_voice_message() else False
+        self._prepend_message = not self.is_voice_message()
 
         self._message_to_prepend = f"[🐾](emoji/5460768917901285539) __{self.command_name}__\n\n"
         self._status_message = "[❤️](emoji/5321387857527447505) __Transcribing...__[✨](emoji/5278352839272309494)"
 
     @property
     def message_to_prepend(self):
-        if self._prepend_message:
-            return self._message_to_prepend
-        else:
-            return ""
+        return self._message_to_prepend if self._prepend_message else ""
 
     @property
     def edit_existing(self):
@@ -45,7 +45,7 @@ class IngTranscribeCommand(Command):
             await self.handle_text_message()
 
     def is_voice_message(self):
-        return hasattr(self.event.message, 'voice') and self.event.message.voice
+        return hasattr(self.event.message, "voice") and self.event.message.voice
 
     async def handle_voice_message(self):
         is_recent = lambda msg_date: (datetime.datetime.now(datetime.timezone.utc) - msg_date).total_seconds() <= 10
@@ -54,34 +54,65 @@ class IngTranscribeCommand(Command):
             logging.info("Ignoring old message")
             return
 
-        await self.client_handler.edit_message(self.peer_id, self.event.message.id,
-                                               self._status_message)
+        await self.client_handler.edit_message(self.peer_id, self.event.message.id, self._status_message)
 
-        voice_job = VoiceJob(self.client_handler, self.event.message)
+        selected_model = self.model or self.client_handler.settings.transcription_model
+        voice_job = VoiceJob(self.client_handler, self.event.message, model=selected_model)
         result = await voice_job.process_job()
-        plain_text = result.get_plain_text()
-
-        await self.send_result(plain_text)
+        await self.send_result(result)
 
     def is_from_peer(self):
         return self.peer_id == self.event.message.from_id or self.event.message.from_id is None
 
     async def send_result(self, result):
-        if self.is_voice_message():
-            await self.client_handler.edit_message(self.peer_id, self.event.message.id,
-                                                   self.message_to_prepend + result)
+        if self.format == "file":
+            await self.client_handler.send_text_as_file(self.peer_id, result.get_plain_text(), "transcription.txt")
+            await self.remove_command_message()
             return
-        elif self.format == "text":
-            if self.edit_existing and self.is_from_peer():
-                await self.client_handler.edit_message(self.peer_id, self.event.message.reply_to_msg_id,
-                                                       self.message_to_prepend + result)
+
+        if self.format == "vtt":
+            if not result.supports_timestamps():
+                await self.client_handler.reply_message(
+                    self.peer_id,
+                    "VTT output requires `whisper-1` timestamp support. Sending plain text instead.",
+                    reply_to=self.event.message.reply_to_msg_id or self.event.message.id,
+                )
             else:
-                await self.client_handler.reply_message(self.peer_id, self.message_to_prepend + result, reply_to=self.event.message.reply_to_msg_id )
-        elif self.format == "file":
-            await self.client_handler.send_text_as_file(self.peer_id, result, "transcription.txt")
-        elif self.format == "vtt":
-            await self.client_handler.reply_message(self.peer_id, "VTT format is not supported yet, sending as file", reply_to=self.event.message.reply_to_msg_id)
-            await self.client_handler.send_text_as_file(self.peer_id, result, "transcription.txt")
+                await self.client_handler.reply_message(
+                    self.peer_id,
+                    "VTT output is not implemented yet. Sending plain text instead.",
+                    reply_to=self.event.message.reply_to_msg_id or self.event.message.id,
+                )
+
+        if self.is_voice_message():
+            await self.client_handler.send_transcript(
+                self.peer_id,
+                result.get_plain_text(),
+                edit_message_id=self.event.message.id,
+                reply_to=self.event.message.id,
+                prepend_message=self.message_to_prepend,
+                prefer_edit=True,
+                is_media_message=True,
+            )
+            return
+
+        if self.format == "text":
+            if self.edit_existing and self.is_from_peer():
+                await self.client_handler.send_transcript(
+                    self.peer_id,
+                    result.get_plain_text(),
+                    edit_message_id=self.event.message.reply_to_msg_id,
+                    reply_to=self.event.message.reply_to_msg_id,
+                    prepend_message=self.message_to_prepend,
+                    prefer_edit=True,
+                )
+            else:
+                await self.client_handler.send_transcript(
+                    self.peer_id,
+                    result.get_plain_text(),
+                    reply_to=self.event.message.reply_to_msg_id,
+                    prepend_message=self.message_to_prepend,
+                )
 
         await self.remove_command_message()
 
@@ -95,24 +126,27 @@ class IngTranscribeCommand(Command):
         if self.is_voice_message():
             return
         await self.client_handler.delete_message(self.peer_id, self.event.message.id)
+
     async def handle_text_message(self):
         await self.set_status(self._status_message, self.event.message, toReplace=True)
         args = self.event.message.message.split()
         await self.parse_args(args)
 
-        message_to_transcribe = await self.client_handler.get_message_by_id(self.peer_id,
-                                                                            self.event.message.reply_to_msg_id)
-        voice_job = VoiceJob(self.client_handler, message_to_transcribe)
+        message_to_transcribe = await self.client_handler.get_message_by_id(
+            self.peer_id,
+            self.event.message.reply_to_msg_id,
+        )
+        selected_model = self.model or self.client_handler.settings.transcription_model
+        voice_job = VoiceJob(self.client_handler, message_to_transcribe, model=selected_model)
         result = await voice_job.process_job()
-        plain_text = result.get_plain_text()
-        await self.send_result(plain_text)
-
+        await self.send_result(result)
 
     async def parse_args(self, args):
-
         for i, arg in enumerate(args):
             if arg in ("-f", "--format") and i + 1 < len(args):
                 self.format = args[i + 1]
+            elif arg in ("-m", "--model") and i + 1 < len(args):
+                self.model = args[i + 1]
             elif arg in ("-s", "--summarize"):
                 self.summarize = True
             elif arg in ("-c", "--chapters"):

--- a/control.py
+++ b/control.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import logging
 
 from telekit_config import Settings, load_settings
+from telekit_config import validate_session_name
 
 ING_TRANSCRIBE_COMMAND_NAME = "@ingTranscribe"
 COMMAND_MODULES = {
@@ -414,17 +415,30 @@ class ClientFactory():
         sessions_location_directory = settings.sessions_dir
         api_id = settings.api_id
         api_hash = settings.api_hash
-        session_name = client_data.get("session_name")
+        session_name = validate_session_name(client_data.get("session_name"))
+        command_objects = [_resolve_command(command) for command in client_data['commands']]
         session_path = Path(sessions_location_directory) / f"{session_name}.session"
         client = TelegramClient(str(session_path), api_id, api_hash)
 
-        command_objects = [_resolve_command(command) for command in client_data['commands']]
         handler = ClientHandler(client, command_objects, settings=settings, session_name=session_name)
 
         return handler
 
 
 def _resolve_command(command_name: str):
+    if command_name not in COMMAND_MODULES:
+        supported = ", ".join(sorted(COMMAND_MODULES))
+        raise ValueError(
+            f"Unknown command '{command_name}' in configuration. Supported commands: {supported}"
+        )
+
     module_name, attribute_name = COMMAND_MODULES[command_name]
-    module = importlib.import_module(module_name)
-    return getattr(module, attribute_name)
+    try:
+        module = importlib.import_module(module_name)
+    except ImportError as exc:
+        raise ImportError(f"Could not import module '{module_name}' for command '{command_name}'.") from exc
+
+    try:
+        return getattr(module, attribute_name)
+    except AttributeError as exc:
+        raise ImportError(f"Could not load '{attribute_name}' from module '{module_name}'.") from exc

--- a/control.py
+++ b/control.py
@@ -1,15 +1,23 @@
-import os
 from io import BytesIO
+import importlib
 
 from telethon import TelegramClient, events
 from telethon.errors import MessageTooLongError, MediaCaptionTooLongError, MessageNotModifiedError, \
     MessageDeleteForbiddenError
 
-from commands import IngTranscribeCommand, IngGPTCommand
 from utils import CustomMarkdown
 from functools import wraps
+from pathlib import Path
 
 import logging
+
+from telekit_config import Settings, load_settings
+
+ING_TRANSCRIBE_COMMAND_NAME = "@ingTranscribe"
+COMMAND_MODULES = {
+    "IngTranscribeCommand": ("commands.ing_transcribe.ing_transcribe", "IngTranscribeCommand"),
+    "IngGPTCommand": ("commands.ing_gpt", "IngGPTCommand"),
+}
 
 logging.basicConfig(level=logging.INFO)
 
@@ -148,7 +156,7 @@ class EventHandler:
             raise TypeError(f"Expected an instance of EventAdapter, but got {type(event_adapter).__name__}.")
 
         if event_adapter.is_voice():
-            return IngTranscribeCommand.command_name
+            return ING_TRANSCRIBE_COMMAND_NAME
         else:
             command_text = event_adapter.get_message_text()
             if not command_text:
@@ -180,8 +188,14 @@ class ClientHandler:
             Downloads the voice message from the given message and saves it to the specified filepath.
     """
 
-    def __init__(self, client, command_classes):
+    TEXT_CHUNK_LIMIT = 3500
+    MEDIA_CAPTION_LIMIT = 900
+    MEDIA_OVERFLOW_NOTICE = "Transcription continues below."
+
+    def __init__(self, client, command_classes, settings: Settings | None = None, session_name: str | None = None):
         self.client = client
+        self.settings = settings or load_settings()
+        self.session_name = session_name or "unknown"
         client.parse_mode = CustomMarkdown()
         self.command_classes = command_classes
         self.event_handler = EventHandler(self)
@@ -195,6 +209,20 @@ class ClientHandler:
 
     async def start(self):
         await self._register_event_handlers()
+        await self.client.connect()
+        is_authorized = await self.client.is_user_authorized()
+        logging.info(
+            "Starting Telegram session '%s' from %s",
+            self.session_name,
+            getattr(self.client.session, "filename", "unknown"),
+        )
+        if is_authorized:
+            logging.info("Session '%s' is already authorized.", self.session_name)
+        else:
+            logging.warning(
+                "Session '%s' is not authorized yet. Telegram will prompt for phone and login code.",
+                self.session_name,
+            )
         await self.client.start()
 
     async def handle_event(self, event):
@@ -202,6 +230,60 @@ class ClientHandler:
 
     async def download_media(self, message, file, progress_callback=None) -> str or None:
         return await self.client.download_media(message, file=file, progress_callback=progress_callback)
+
+    @classmethod
+    def split_text_chunks(cls, text, limit=None):
+        limit = limit or cls.TEXT_CHUNK_LIMIT
+        normalized_text = (text or "").strip()
+        if not normalized_text:
+            return []
+
+        chunks = []
+        remaining = normalized_text
+        while len(remaining) > limit:
+            split_at = cls._find_chunk_boundary(remaining, limit)
+            chunk = remaining[:split_at].strip()
+            if not chunk:
+                chunk = remaining[:limit].strip()
+                split_at = len(chunk)
+            chunks.append(chunk)
+            remaining = remaining[split_at:].strip()
+
+        if remaining:
+            chunks.append(remaining)
+
+        return chunks
+
+    @staticmethod
+    def _find_chunk_boundary(text, limit):
+        split_at = text.rfind("\n", 0, limit + 1)
+        if split_at == -1 or split_at < limit // 2:
+            split_at = text.rfind(" ", 0, limit + 1)
+        if split_at == -1 or split_at < limit // 2:
+            return limit
+        return split_at
+
+    @classmethod
+    def compose_transcript_chunks(cls, text, prepend_message=""):
+        prefix = prepend_message or ""
+        base_chunks = cls.split_text_chunks(text)
+        if not base_chunks:
+            return [prefix.strip()] if prefix.strip() else []
+        if not prefix:
+            return base_chunks
+
+        first_limit = max(1, cls.TEXT_CHUNK_LIMIT - len(prefix))
+        normalized_text = (text or "").strip()
+        if not normalized_text:
+            return [prefix.strip()]
+        if len(normalized_text) <= first_limit:
+            return [prefix + normalized_text]
+
+        first_boundary = cls._find_chunk_boundary(normalized_text, first_limit)
+        first_chunk = normalized_text[:first_boundary].strip()
+        remainder = normalized_text[first_boundary:].strip()
+        remaining_chunks = cls.split_text_chunks(remainder)
+        return [prefix + first_chunk] + remaining_chunks
 
     async def send_text_as_file(self, peer_id, text, filename, reply_to=None):
         text_bytes = text.encode('utf-8')
@@ -212,6 +294,71 @@ class ClientHandler:
             await self.client.send_file(peer_id, buffer, reply_to=reply_to)
         else:
             await self.client.send_file(peer_id, buffer)
+
+    async def send_transcript(
+        self,
+        peer_id,
+        text,
+        *,
+        edit_message_id=None,
+        reply_to=None,
+        prepend_message="",
+        prefer_edit=False,
+        is_media_message=False,
+        parse_mode=None,
+    ):
+        parse_mode = parse_mode or self.client.parse_mode
+        chunks = self.compose_transcript_chunks(text, prepend_message=prepend_message)
+        if not chunks:
+            return
+
+        if is_media_message and prefer_edit and edit_message_id is not None:
+            first_chunk = chunks[0]
+            if len(first_chunk) <= self.MEDIA_CAPTION_LIMIT:
+                try:
+                    await self.client.edit_message(peer_id, edit_message_id, first_chunk, parse_mode=parse_mode)
+                    for chunk in chunks[1:]:
+                        await self.client.send_message(peer_id, chunk, reply_to=reply_to or edit_message_id, parse_mode=parse_mode)
+                    return
+                except MediaCaptionTooLongError:
+                    logging.warning("Caption too long for media edit, falling back to replies")
+                except MessageNotModifiedError:
+                    logging.warning("Message not modified")
+
+            notice = prepend_message + self.MEDIA_OVERFLOW_NOTICE if prepend_message else self.MEDIA_OVERFLOW_NOTICE
+            try:
+                await self.client.edit_message(
+                    peer_id,
+                    edit_message_id,
+                    notice[:self.MEDIA_CAPTION_LIMIT],
+                    parse_mode=parse_mode,
+                )
+            except (MediaCaptionTooLongError, MessageNotModifiedError):
+                pass
+
+            for chunk in chunks:
+                await self.client.send_message(
+                    peer_id,
+                    chunk,
+                    reply_to=reply_to or edit_message_id,
+                    parse_mode=parse_mode,
+                )
+            return
+
+        if prefer_edit and edit_message_id is not None:
+            first_chunk = chunks[0]
+            await self.client.edit_message(peer_id, edit_message_id, first_chunk, parse_mode=parse_mode)
+            for chunk in chunks[1:]:
+                await self.client.send_message(
+                    peer_id,
+                    chunk,
+                    reply_to=reply_to or edit_message_id,
+                    parse_mode=parse_mode,
+                )
+            return
+
+        for chunk in chunks:
+            await self.client.send_message(peer_id, chunk, reply_to=reply_to, parse_mode=parse_mode)
 
     async def delete_message(self, peer_id, message_id):
         try:
@@ -262,14 +409,22 @@ class ClientHandler:
 
 class ClientFactory():
     @staticmethod
-    def create_client(client_data) -> 'ClientHandler':
-        sessions_location_directory = '/app/data/sessions/'
-        api_id = os.getenv("API_ID")
-        api_hash = os.getenv("API_HASH")
+    def create_client(client_data, settings: Settings | None = None) -> 'ClientHandler':
+        settings = settings or load_settings()
+        sessions_location_directory = settings.sessions_dir
+        api_id = settings.api_id
+        api_hash = settings.api_hash
         session_name = client_data.get("session_name")
-        client = TelegramClient(sessions_location_directory + session_name + ".session", api_id, api_hash)
+        session_path = Path(sessions_location_directory) / f"{session_name}.session"
+        client = TelegramClient(str(session_path), api_id, api_hash)
 
-        command_objects = [eval(command) for command in client_data['commands']]
-        handler = ClientHandler(client, command_objects)
+        command_objects = [_resolve_command(command) for command in client_data['commands']]
+        handler = ClientHandler(client, command_objects, settings=settings, session_name=session_name)
 
         return handler
+
+
+def _resolve_command(command_name: str):
+    module_name, attribute_name = COMMAND_MODULES[command_name]
+    module = importlib.import_module(module_name)
+    return getattr(module, attribute_name)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,3 +19,13 @@ services:
     volumes:
       - ./data:/app/data
       - ./jobs:/app/jobs
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - "from pathlib import Path; import sys; cmd = Path('/proc/1/cmdline').read_text(); ok = 'telekit' in cmd and Path('/app/data').exists() and Path('/app/data/clients.json').exists(); sys.exit(0 if ok else 1)"
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  telekit:
+    container_name: telekit
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    env_file:
+      - ./.env
+    environment:
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      API_ID: ${API_ID}
+      API_HASH: ${API_HASH}
+      TELEKIT_TRANSCRIPTION_MODEL: ${TELEKIT_TRANSCRIPTION_MODEL:-whisper-1}
+      TELEKIT_DATA_DIR: /app/data
+      TELEKIT_CLIENTS_FILE: /app/data/clients.json
+      TELEKIT_SESSIONS_DIR: /app/data/sessions
+      TELEKIT_JOBS_DIR: /app/jobs
+    volumes:
+      - ./data:/app/data
+      - ./jobs:/app/jobs

--- a/docs/exec_plans/active/2026-03-07-telekit-runtime-transcription-execplan.md
+++ b/docs/exec_plans/active/2026-03-07-telekit-runtime-transcription-execplan.md
@@ -1,0 +1,357 @@
+# ExecPlan: Align Telekit Runtime, Configurable Transcription Models, and User Help
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+`PLANS.md` is checked into this repository at `PLANS.md`. This plan must be maintained in accordance with that file.
+
+## Purpose / Big Picture
+
+After this change, Telekit will become installable and understandable for a non-expert user. A user will be able to choose one supported installation path, run `--help` without guessing missing dependencies, understand what the bot can do, understand how to trigger transcription in Telegram, and choose the transcription model through environment variables or command-line flags.
+
+This work also fixes two broken behaviors. First, long-audio handling currently fails in the chunking path because the code sends `pydub` audio segment objects to the OpenAI client instead of real audio files. Second, when a transcript becomes too long for a Telegram message, the bot currently falls back to sending `transcription.txt`; the new behavior must prefer editing or replying in multiple text chunks when possible, and only use a file when the selected output format or Telegram constraints make text impossible.
+
+The end result must be observable in three ways. A local developer can run a documented `uv` workflow and see `telekit --help` output. A Docker operator can build and run the same program using the same configuration keys. A Telegram user can read the README, send or reply to a voice note, and understand exactly what the bot does and how to control it.
+
+## Progress
+
+- [x] (2026-03-07 15:10Z) Completed repo exploration, issue `#3` review, OpenAI speech-to-text surface verification, and server-side deployment spot check.
+- [x] (2026-03-07 15:18Z) Confirmed local install drift: `requirements.txt` omits `python-dotenv` and `pydub` while `Dockerfile` installs them separately.
+- [x] (2026-03-07 15:23Z) Confirmed model hard-coding to `whisper-1` and verified the current code depends on `verbose_json` segment output.
+- [x] (2026-03-07 15:29Z) Confirmed `uv` viability with Python 3.9 and 3.12 after dependency correction; confirmed Python 3.13 is not supported by the current Telethon pin.
+- [x] (2026-03-07 15:37Z) Authored this ExecPlan in `docs/exec_plans/active/` so implementation can proceed against a shared spec.
+- [x] (2026-03-07 16:42Z) Landed package/runtime alignment, shared settings, local/Docker-safe path handling, and `uv`-managed CLI help coverage.
+- [x] (2026-03-07 16:44Z) Landed normalized transcription responses, model selection support, long-audio chunk file export, and Telegram inline chunk delivery.
+- [x] (2026-03-07 16:40Z) Rewrote README and `.env.example` around the shipped self-automation workflow, Telegram trigger syntax, and real capability/limitation boundaries.
+- [x] (2026-03-07 16:58Z) Fixed post-merge review regressions: process-level `--transcription-model` now reaches `VoiceJob`, singular and plural session-dir env names are both accepted, docs match the active config surface, and build/cache artifacts are ignored.
+- [ ] End-to-end validation across local `uv` workflow and Docker workflow remains to be fully run after the final merged tree stabilizes. Local `uv` validation is complete; Docker daemon validation is still limited by host availability.
+
+## Surprises & Discoveries
+
+- Observation: `telekit/AGENTS.md` references `.agents/PLANS.md`, but the actual plan guidance file in this repository is `PLANS.md` at the root.
+  Evidence: `AGENTS.md` contains “as described in .agents/PLANS.md”, while `find` returns `telekit/PLANS.md` and `telekit/.agents/` is empty.
+
+- Observation: the documented local path fails before any command help is shown.
+  Evidence: running `python3 app.py --help` in the repository currently raises `ModuleNotFoundError: No module named 'dotenv'`.
+
+- Observation: the local and Docker session paths differ, so the README’s non-Docker path is not actually first-class.
+  Evidence: `control.py` creates Telethon sessions under `/app/data/sessions/`, which only exists inside the container image.
+
+- Observation: the long-audio path is structurally broken.
+  Evidence: `utils.AudioHelper.split_audio()` returns `AudioSegment` objects, while `job_manager.voice_job.VoiceJob.process_job()` passes those objects to `openai.Audio.atranscribe()`, which expects a file-like object with a filename.
+
+- Observation: newer GPT transcription models are supported by the current OpenAI speech-to-text API, but they do not support the same output formats as `whisper-1`.
+  Evidence: current OpenAI documentation states `whisper-1` supports `json`, `text`, `srt`, `verbose_json`, and `vtt`, while `gpt-4o-transcribe` and `gpt-4o-mini-transcribe` support `json` or `text`.
+
+- Observation: the current server deployment uses an untracked `docker-compose.yaml` and Docker daemon access is restricted for the current SSH user.
+  Evidence: server `git status --short` shows `?? docker-compose.yaml`, and `docker compose ps` fails with `permission denied` on `/var/run/docker.sock`.
+
+- Observation: the first merged implementation left a gap between process-level settings and per-message transcription jobs.
+  Evidence: after wiring `start-program --transcription-model`, `load_settings(transcription_model='gpt-4o-mini-transcribe')` reported the chosen model while a default `VoiceJob(..., model=None)` still resolved to `whisper-1` until `IngTranscribeCommand` was updated to read `client_handler.settings.transcription_model`.
+
+- Observation: docs and config drift can reappear quickly when env var names are changed in only one layer.
+  Evidence: `.env.example` and `README.md` initially documented `TELEKIT_SESSION_DIR`, while `telekit_config.py` only read `TELEKIT_SESSIONS_DIR`.
+
+## Decision Log
+
+- Decision: treat `PLANS.md` at the repository root as the operative ExecPlan contract for this repository.
+  Rationale: `AGENTS.md` points to a non-existent `.agents/PLANS.md`, but the repository already contains a complete root-level `PLANS.md` with the required format and rules.
+  Date/Author: 2026-03-07 / Codex
+
+- Decision: make `uv` the recommended local development path, but keep Docker as the recommended operator path for non-technical users.
+  Rationale: `uv` reduces environment setup friction for developers and can manage Python versions, but Docker remains the lowest-friction deployment path for operators who do not want to manage local Python packaging.
+  Date/Author: 2026-03-07 / Codex
+
+- Decision: declare Python support as `>=3.10,<3.13` unless code and dependencies are upgraded further during implementation.
+  Rationale: the current Telethon pin works in Python 3.10 and 3.12 in local checks once dependencies are corrected, but fails on Python 3.13 because `imghdr` has been removed from the standard library.
+  Date/Author: 2026-03-07 / Codex
+
+- Decision: preserve `whisper-1` as the default transcription model in the first implementation pass, while adding support for `gpt-4o-transcribe` and `gpt-4o-mini-transcribe`.
+  Rationale: the current result parser assumes timestamped `verbose_json` segments, which map naturally to `whisper-1`. The GPT transcription models should be supported, but through a normalized parsing layer rather than a hard swap that breaks current text assembly.
+  Date/Author: 2026-03-07 / Codex
+
+- Decision: long transcript delivery should prefer Telegram text, including multi-message chunking, before falling back to a `.txt` file.
+  Rationale: a text file is a poor default user experience when the desired result is readable inline. The fallback file path should remain available only for explicit file output mode or unavoidable Telegram/API constraints.
+  Date/Author: 2026-03-07 / Codex
+
+- Decision: explicitly document unimplemented features rather than implying they work.
+  Rationale: the codebase currently advertises “various output formats” and contains flags like `--summarize` and `--chapters` that are not implemented. Trust improves when unsupported behavior is labeled as planned rather than hidden.
+  Date/Author: 2026-03-07 / Codex
+
+- Decision: accept both `TELEKIT_SESSIONS_DIR` and the older singular alias `TELEKIT_SESSION_DIR`, but document the plural form as canonical.
+  Rationale: the singular form had already appeared in the merged docs surface and may exist in copied local env files. Supporting both names avoids needless breakage while preserving one preferred config key going forward.
+  Date/Author: 2026-03-07 / Codex
+
+## Outcomes & Retrospective
+
+Current outcome snapshot:
+
+- The local developer path is now centered on `uv`, and `uv run telekit --help` works against the merged tree.
+- The transcription path now supports configurable selection across `whisper-1`, `gpt-4o-transcribe`, and `gpt-4o-mini-transcribe`, with normalization for model response shape differences.
+- Long transcripts stay inline in Telegram through chunked text replies before the program falls back to `transcription.txt`.
+- Long-audio chunking now writes real exported chunk files before sending them to OpenAI.
+- Post-merge review found and fixed two integration regressions: CLI model propagation into runtime jobs and env-name drift for session directory overrides.
+
+Remaining gaps:
+
+- Docker image validation is structurally updated but still needs a full daemon-backed build/run verification in an environment where Docker is available.
+- `IngGPTCommand`, summarization, chapter generation, and real VTT output remain incomplete by design.
+
+## Context and Orientation
+
+Telekit is a small Python project that automates actions in a user’s own Telegram account using Telethon, which is a Python client library for Telegram. The main command-line entrypoint is `app.py`. It defines Typer commands such as `add-client`, `delete-client`, and `start-program`, and it persists configured sessions in `data/clients.json`.
+
+The runtime wiring lives in `control.py`. `ClientFactory.create_client()` creates Telethon clients from the JSON file, and `ClientHandler` registers message handlers for outgoing Telegram messages. In Telekit’s current design, the bot listens only to outgoing messages (`events.NewMessage(incoming=False)`), which means the user triggers behavior from their own account rather than from a separate bot account.
+
+The transcription command lives in `commands/ing_transcribe/ing_transcribe.py`. A “command” in this repository means a class derived from `commands.base.Command` that inspects an event and performs an action. The transcription command triggers automatically for voice messages the user sends and also when the user replies with `@` or `@ingTranscribe` to an existing voice note.
+
+Audio download and transcription work live in `job_manager/voice_job.py`, `job_manager/transcription_result.py`, and `utils.py`. A “job” here means a unit of work that downloads one Telegram voice message, writes temporary files under `jobs/<uuid>/`, and then sends audio to OpenAI’s transcription API. `TranscriptionResult` currently assumes a `verbose_json` response with timestamped `segments`, which is why model support needs to be normalized before alternative models become configurable.
+
+The current packaging and deployment surfaces are inconsistent:
+
+- `requirements.txt` contains only `Typer`, `Telethon`, `cryptg`, and `openai`.
+- `Dockerfile` installs `python-dotenv` and `pydub` outside `requirements.txt`.
+- `.env.example` includes only `OPENAI_API_KEY`, `API_ID`, and `API_HASH`.
+- `README.md` documents basic commands but does not explain triggers, help output, supported Python versions, supported models, or actual capabilities and limitations.
+
+The current server deployment at `192.168.50.120` contains a `telekit` checkout with an untracked `docker-compose.yaml`. That deployment context matters because local and Docker workflows must converge instead of drifting further.
+
+## Plan of Work
+
+### Milestone 1: Make packaging, configuration, and runtime paths consistent
+
+This milestone makes the repository installable and runnable from one declared contract. At the end of this milestone, a novice can clone the repository, create or synchronize a local environment with `uv`, run `--help`, and understand which Python versions are supported.
+
+Add a project packaging file at the repository root. Use `pyproject.toml` as the source of truth for project metadata, Python version constraints, dependencies, and a console script entrypoint named `telekit`. Keep `requirements.txt` only if needed for compatibility, but generate it from the same dependency set or clearly label it as legacy. The dependency set must include `python-dotenv` and `pydub`, and the `cryptg` pin must be updated to a version that installs cleanly in supported Python versions. If `cryptg` is made optional, the plan must document the performance tradeoff and keep runtime behavior correct without it.
+
+Create one configuration module, for example `telekit_config.py` or `config.py`, that loads environment variables and exposes a single authoritative settings object. This module must define and validate:
+
+- Telegram API credentials.
+- OpenAI API key.
+- Session root directory.
+- Jobs directory.
+- Default transcription model.
+- Default text output mode.
+- Optional chunk size or Telegram message splitting controls.
+
+Replace hard-coded `/app/...` paths in `control.py` and any other modules with settings-based paths. The settings must default to repository-local paths such as `data/sessions` and `jobs` for local runs, while Docker can override them through environment variables or volume mounts.
+
+Update the CLI entrypoint in `app.py` so `telekit --help` and `python app.py --help` both work. Keep the existing commands for compatibility, but improve their help text so a novice understands what each one does. Add a top-level help paragraph explaining that Telekit is a Telegram self-automation client and not a separate Telegram bot account.
+
+Update `Dockerfile` so it installs from the same declared dependency source as local development. Remove duplicated ad hoc installs that drift from the main dependency list. Remove the unused exposed port unless a real HTTP surface is introduced during the same change. Ensure the Docker default command still starts the long-running program.
+
+### Milestone 2: Add explicit model selection and normalize transcription responses
+
+This milestone makes the transcription model configurable without breaking current text assembly. At the end of this milestone, the operator can set the model in `.env` or override it through CLI flags, and Telekit can successfully process supported responses from `whisper-1`, `gpt-4o-transcribe`, and `gpt-4o-mini-transcribe`.
+
+Introduce a normalized transcription layer in `job_manager/transcription_result.py` or a new adjacent module. The normalization layer must accept two response families:
+
+- `whisper-1` style verbose responses with `segments`.
+- GPT transcription responses that return `json` or `text` content without the same segment structure.
+
+The normalized result object must expose methods used by the rest of the program in plain language, such as `get_plain_text()`, `get_segments()`, and `supports_timestamps()`. If timestamps are unavailable for a model, the result must still produce correct plain text and explicitly report that timestamp-derived formats such as `vtt` are unavailable.
+
+Update `job_manager/voice_job.py` so the model is not hardcoded. Read it from the shared configuration object, allow an override argument from the CLI or command path, and validate it against an allowed set:
+
+- `whisper-1`
+- `gpt-4o-transcribe`
+- `gpt-4o-mini-transcribe`
+
+When the selected model does not support a requested output mode, fail gracefully with an explanatory Telegram message or CLI error rather than silently producing the wrong format. For example, if `vtt` is requested under `gpt-4o-mini-transcribe`, the program should say that the current model does not support that output and suggest `whisper-1` instead.
+
+Add operator-facing configuration precedence and document it clearly:
+
+1. Command-line flag, such as `telekit start-program --transcription-model gpt-4o-mini-transcribe`.
+2. Environment variable, such as `TELEKIT_TRANSCRIPTION_MODEL`.
+3. Project default, initially `whisper-1`.
+
+### Milestone 3: Fix long-audio processing and long-text Telegram delivery
+
+This milestone removes the broken large-file path and improves user-visible output when transcripts are long. At the end of this milestone, large recordings can be transcribed successfully, and long transcript output stays inline in Telegram whenever feasible.
+
+Rewrite `utils.AudioHelper.split_audio()` so it returns real temporary audio files or writes chunks to a deterministic temporary directory under the current job directory. A segment file must have a stable extension and filename so OpenAI’s client can send it correctly. The chunking code must clean up or safely overwrite its own artifacts when retried.
+
+Update `job_manager/voice_job.py` so the long-audio branch opens each chunk as a file and passes that file object to the OpenAI client. When combining chunk results, preserve text order and any supported timestamps. If the model supports prompting and previous-context continuation, pass the trailing text from the prior chunk to improve continuity. Keep this behavior optional and documented because prompt support differs by model.
+
+Replace the current “send `transcription.txt` when text length exceeds 4096” default in `control.py`. Introduce a delivery helper that can:
+
+- Edit the original message if the entire transcript fits.
+- Edit the original message with the first chunk and send follow-up replies for the remaining chunks when the transcript exceeds Telegram’s message size.
+- Send a file only when the user explicitly asks for file output or when the selected output format is file-oriented.
+
+The exact chunk size should leave safety headroom under Telegram’s limit, for example 3500 to 3800 characters per chunk, to account for prefixes and formatting. Preserve the current prepend banner only on the first chunk so the reply thread stays readable.
+
+Ensure this logic works both for automatic transcription of the user’s own voice messages and for reply-triggered transcription of someone else’s voice message.
+
+### Milestone 4: Clarify the product surface, help, and onboarding
+
+This milestone closes the usability gaps raised in issue `#3`. At the end of this milestone, a non-expert can understand prerequisites, installation choices, the Telegram trigger syntax, real capabilities, real limitations, and where model selection lives.
+
+Rewrite `README.md` from the perspective of a novice user. It must contain:
+
+- A clear one-paragraph description of what Telekit is.
+- A “What it can do today” section.
+- A “What is planned but not implemented yet” section.
+- A recommended install path for Docker users.
+- A recommended install path for local developers using `uv`.
+- A troubleshooting section for missing credentials, missing Python version, and failed Telethon session setup.
+- A “How to use in Telegram” section with concrete examples of sending a voice note yourself and replying `@` to someone else’s voice note.
+- A section explaining how to show help and inspect command options.
+
+Update `.env.example` with every supported runtime configuration key, including model selection and path overrides. Each variable should include a short comment in the README explaining what it does and when a user should change it.
+
+Add command help text and, if it is low-risk, a small in-chat help surface. For example, allow replying `@ --help` or `@ingTranscribe --help` to get a brief usage message in Telegram. If that is too invasive for the first pass, at minimum the README must explain the in-chat trigger syntax and the CLI help commands clearly.
+
+Audit feature claims against the code. Remove or relabel claims about summarization, chapters, GPT command support, or VTT support if they are not actually implemented. If the placeholder `IngGPTCommand` remains unimplemented, either remove it from the default client command list or clearly mark it as disabled/incomplete.
+
+### Milestone 5: Validate the unified contract across local and Docker workflows
+
+This milestone proves the work is real rather than theoretical. At the end of this milestone, the repository will contain validation evidence showing that the documented commands and behaviors match the code.
+
+Run the local developer path from a clean shell using `uv`. Confirm that `telekit --help`, `telekit add-client --help`, and `telekit start-program --help` work without manually installing undeclared packages.
+
+Run a targeted unit or integration suite that covers:
+
+- Configuration loading and precedence.
+- Response normalization for `whisper-1` and GPT transcription result shapes.
+- Long-audio chunk file creation and merge behavior.
+- Telegram text chunking behavior for oversized transcripts.
+
+Build the Docker image using the updated Dockerfile and confirm that the same configuration variables are honored there. If server-side Docker execution remains inaccessible for the current SSH user, note that limitation explicitly and keep Docker verification local.
+
+Update this ExecPlan’s `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` sections as each milestone completes. The plan itself is part of the delivery artifact.
+
+## Concrete Steps
+
+Run every command from the repository root unless a different directory is specified. Re-run commands freely; the intended commands below are idempotent.
+
+1. Inspect current dependency and runtime behavior before changing code.
+
+    pwd
+    python3 app.py --help || true
+    uv --version
+
+   Expected current failure before the implementation:
+
+    Traceback (most recent call last):
+      ...
+    ModuleNotFoundError: No module named 'dotenv'
+
+2. After packaging changes land, verify the local development workflow.
+
+    uv sync
+    uv run telekit --help
+    uv run telekit add-client --help
+    uv run telekit start-program --help
+
+   Expected success shape after the implementation:
+
+    Usage: telekit [OPTIONS] COMMAND [ARGS]...
+    ...
+    Commands:
+      add-client
+      delete-client
+      start-program
+
+3. Run the automated test suite added for this plan.
+
+    uv run pytest
+
+   If the repository uses another command for tests by the time implementation is complete, replace this step in the plan with the exact command used in the codebase and keep the expected output updated.
+
+4. Validate the long-text delivery helper with unit tests and, if available, a small fake client test.
+
+    uv run pytest -k "telegram or transcription or config"
+
+5. Validate Docker packaging.
+
+    docker build -t telekit:execplan .
+
+   If Docker is unavailable locally, document the limitation in this plan and record the exact error.
+
+6. Validate README instructions manually against the actual commands.
+
+    uv run telekit --help
+    uv run telekit add-client demo_session
+
+7. Optionally validate the server filesystem layout through SSH without requiring Docker daemon access.
+
+    /Users/ivan/.codex/skills/00-ssh-proxmox-vm-access/scripts/ssh_run.sh -- 'cd telekit && git status --short && ls -la'
+
+## Validation and Acceptance
+
+This plan is accepted only when all of the following behaviors are true and demonstrated:
+
+1. A clean local environment can install and run Telekit help output without undocumented dependency fixes.
+2. The repository clearly states which Python versions are supported, and the local workflow reflects that contract.
+3. The transcription model can be selected through environment variables and overridden through a CLI flag.
+4. `whisper-1`, `gpt-4o-transcribe`, and `gpt-4o-mini-transcribe` are supported as selectable models, with graceful errors for unsupported output modes.
+5. Audio larger than the old single-file threshold is processed through real chunk files and produces a combined transcript.
+6. Oversized transcripts remain readable inline in Telegram by splitting across edited or reply messages before falling back to `transcription.txt`.
+7. The README explains real capabilities, real limitations, installation, help commands, and Telegram trigger syntax.
+8. Placeholder or misleading feature claims are removed or explicitly marked as not implemented.
+9. Docker and local runtime surfaces use the same configuration names and the same dependency contract.
+
+## Idempotence and Recovery
+
+All path and packaging changes in this plan should be additive and repeatable. Running `uv sync` repeatedly must converge on the same environment. Running the CLI help commands repeatedly must not mutate runtime state. Creating local directories such as `data/sessions` or `jobs` must be safe if they already exist.
+
+If the packaging migration introduces breakage, keep a compatibility entrypoint so `python app.py ...` still works while `telekit ...` is introduced. If a dependency upgrade causes an unexpected runtime regression, revert only the dependency pin and keep the rest of the packaging structure intact so the repository does not lose the new unified contract.
+
+If Docker validation cannot be completed because of daemon permissions on the remote host, note the failure in this plan and perform the image build locally. Do not change the remote server deployment as part of this plan unless separately requested.
+
+## Artifacts and Notes
+
+Important current evidence captured during planning:
+
+    python3 app.py --help
+    Traceback (most recent call last):
+      ...
+    ModuleNotFoundError: No module named 'dotenv'
+
+    uv run --python 3.13 ... python app.py --help
+    ...
+    ModuleNotFoundError: No module named 'imghdr'
+
+Key current file references:
+
+- `app.py` defines the Typer CLI and default client command registration.
+- `control.py` registers Telethon handlers and currently hardcodes `/app/data/sessions/`.
+- `commands/ing_transcribe/ing_transcribe.py` defines the Telegram trigger syntax and text/file output behavior.
+- `job_manager/voice_job.py` hardcodes `whisper-1` and contains the broken long-audio path.
+- `job_manager/transcription_result.py` assumes `verbose_json` segment output.
+- `utils.py` defines audio conversion and splitting helpers.
+- `README.md`, `.env.example`, and `Dockerfile` define the current user-facing operator surface.
+
+Parallel implementation ownership for asynchronous workers:
+
+- Worker A owns packaging/runtime alignment and CLI contract. Files: `pyproject.toml`, `requirements.txt`, `app.py`, `control.py`, `Dockerfile`, new config module, and related tests.
+- Worker B owns transcription engine normalization, configurable models, long-audio chunking, and long-text Telegram delivery. Files: `job_manager/voice_job.py`, `job_manager/transcription_result.py`, `utils.py`, `commands/ing_transcribe/ing_transcribe.py`, `control.py` delivery helpers, and related tests.
+- Worker C owns user-facing docs and capability/help clarity. Files: `README.md`, `.env.example`, any additional docs, and any small help-surface edits that do not conflict with Worker A or B ownership.
+
+The integrating agent owns this ExecPlan file, final conflict resolution, and final verification.
+
+## Interfaces and Dependencies
+
+The implementation must end with these stable interfaces or equivalent names that are documented in code and README:
+
+In the shared configuration module, define a single settings object or dataclass that exposes:
+
+    telegram_api_id: str
+    telegram_api_hash: str
+    openai_api_key: str
+    session_dir: Path
+    jobs_dir: Path
+    transcription_model: str
+    transcript_delivery_mode: str
+
+In `job_manager/transcription_result.py`, define a normalized result type that can represent both timestamped and plain-text responses. The result type must expose methods equivalent to:
+
+    get_plain_text() -> str
+    get_segments() -> list
+    supports_timestamps() -> bool
+
+In `job_manager/voice_job.py`, define a transcription entrypoint that accepts model selection through configuration or an explicit argument rather than a hardcoded string.
+
+In the Telegram delivery path, define one helper that takes a peer ID, transcript text, reply target, and mode, and decides whether to edit, reply in multiple chunks, or send a file.
+
+Revision note (2026-03-07): Initial ExecPlan created to convert the earlier recommendation set into a repository-native implementation spec with explicit milestones, validation, worker ownership, and the additional long-transcript delivery fix requested after planning.

--- a/job_manager/transcription_result.py
+++ b/job_manager/transcription_result.py
@@ -1,33 +1,106 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class TranscriptionSegment:
+    start: float
+    text: str
+
+
 class TranscriptionResult:
-    def __init__(self, verbose_answer):
-        self._result = {
-            "segments": []
-        }
-        self.duration = verbose_answer["duration"]
-        self.verbose_answer = verbose_answer
-        for segment in verbose_answer["segments"]:
-            self._result["segments"].append({
-                "start": segment["start"],
-                "text": segment["text"]
-            })
+    def __init__(self, segments: list[TranscriptionSegment] | None = None, has_timestamps: bool = False):
+        self._segments = segments or []
+        self._has_timestamps = has_timestamps
 
-    def add_verbose_answer(self, verbose_answer):
-        for segment in verbose_answer["segments"]:
-            self._result["segments"].append({
-                "start": segment["start"] + self.duration,
-                "text": segment["text"]
-            })
+    @classmethod
+    def from_response(
+        cls,
+        response: Any,
+        *,
+        start_offset: float = 0.0,
+        fallback_duration: float = 0.0,
+    ) -> "TranscriptionResult":
+        payload = cls._coerce_payload(response)
+        segments_payload = payload.get("segments")
 
-        self.duration += verbose_answer["duration"]
+        if isinstance(segments_payload, list) and segments_payload:
+            segments = [
+                TranscriptionSegment(
+                    start=float(segment.get("start", 0.0)) + start_offset,
+                    text=str(segment.get("text", "")),
+                )
+                for segment in segments_payload
+                if str(segment.get("text", "")).strip()
+            ]
+            return cls(segments=segments, has_timestamps=True)
 
-    def get_plain_text(self):
-        text = ""
-        for segment in self._result["segments"]:
-            text += segment["text"]
+        text = cls._extract_text(payload, response)
+        segments = [TranscriptionSegment(start=start_offset, text=text)] if text else []
+        result = cls(segments=segments, has_timestamps=False)
+        result._fallback_duration = fallback_duration
+        return result
 
-        text = text[1:] if text[0] == " " else text
+    @staticmethod
+    def _coerce_payload(response: Any) -> dict[str, Any]:
+        if hasattr(response, "to_dict_recursive"):
+            return response.to_dict_recursive()
+        if isinstance(response, dict):
+            return response
+        if isinstance(response, str):
+            return {"text": response}
+        return {}
 
-        return text
+    @staticmethod
+    def _extract_text(payload: dict[str, Any], response: Any) -> str:
+        text = payload.get("text") or payload.get("transcript") or payload.get("raw_text")
+        if text is not None:
+            return str(text).strip()
+        if isinstance(response, str):
+            return response.strip()
+        return ""
 
-    def get_json(self):
-        return self._result
+    def append(
+        self,
+        response: Any,
+        *,
+        start_offset: float = 0.0,
+        fallback_duration: float = 0.0,
+    ) -> None:
+        had_segments = bool(self._segments)
+        next_result = self.from_response(
+            response,
+            start_offset=start_offset,
+            fallback_duration=fallback_duration,
+        )
+        if (
+            self._segments
+            and next_result._segments
+            and not next_result._has_timestamps
+            and self._segments[-1].text
+            and next_result._segments[0].text
+            and not self._segments[-1].text.endswith((" ", "\n", "\t"))
+            and not next_result._segments[0].text.startswith((" ", "\n", "\t", ".", ",", "!", "?", ":", ";"))
+        ):
+            next_result._segments[0].text = f" {next_result._segments[0].text}"
+        self._segments.extend(next_result._segments)
+        self._has_timestamps = (
+            self._has_timestamps and next_result._has_timestamps
+            if had_segments
+            else next_result._has_timestamps
+        )
+
+    def get_plain_text(self) -> str:
+        text = "".join(segment.text for segment in self._segments).strip()
+        return text[1:] if text.startswith(" ") else text
+
+    def get_segments(self) -> list[dict[str, Any]]:
+        return [{"start": segment.start, "text": segment.text} for segment in self._segments]
+
+    def supports_timestamps(self) -> bool:
+        return self._has_timestamps
+
+    def get_json(self) -> dict[str, Any]:
+        return {"segments": self.get_segments()}

--- a/job_manager/voice_job.py
+++ b/job_manager/voice_job.py
@@ -58,7 +58,7 @@ class VoiceJob(BaseJob):
             logger.info("Audio file is too large (%s MB), splitting into smaller segments", size)
             return await self.transcribe_chunks(converted_media_path)
 
-        return await self.transcribe(self.get_file_path())
+        return await self.transcribe(converted_media_path)
 
     async def transcribe_chunks(self, file_path) -> TranscriptionResult:
         audio_chunks = AudioHelper.split_audio(file_path, self.get_chunk_directory())

--- a/job_manager/voice_job.py
+++ b/job_manager/voice_job.py
@@ -1,47 +1,80 @@
-from .job import BaseJob
-from utils import AudioHelper
+import os
+
 import openai
+
+from .job import BaseJob
 from job_manager.transcription_result import TranscriptionResult
+from utils import AudioHelper
 
 import logging
-logger = logging.getLogger(__name__)
 
+logger = logging.getLogger(__name__)
 
 
 class VoiceJob(BaseJob):
     SIZE_LIMIT = 20
+    DEFAULT_MODEL = "whisper-1"
+    SUPPORTED_MODELS = {
+        "whisper-1",
+        "gpt-4o-transcribe",
+        "gpt-4o-mini-transcribe",
+    }
 
-    def __init__(self, client_handler, message):
+    def __init__(self, client_handler, message, model=None):
         super().__init__(client_handler, message)
         self._job_directory = self._create_job_directory()
         self._prompt = ""
         self._client_handler = client_handler
+        self._model = self.resolve_model(model)
+
+    @classmethod
+    def resolve_model(cls, model=None):
+        selected_model = (
+            model
+            or os.getenv("TELEKIT_TRANSCRIPTION_MODEL")
+            or os.getenv("TRANSCRIPTION_MODEL")
+            or cls.DEFAULT_MODEL
+        )
+        if selected_model not in cls.SUPPORTED_MODELS:
+            logger.warning("Unsupported transcription model %s, falling back to %s", selected_model, cls.DEFAULT_MODEL)
+            return cls.DEFAULT_MODEL
+        return selected_model
 
     def get_file_path(self):
-        return self._job_directory + "/" + self._id + ".ogg"
+        return os.path.join(self._job_directory, f"{self._id}.ogg")
+
+    def get_chunk_directory(self):
+        return os.path.join(self._job_directory, "chunks")
+
+    def get_response_format(self):
+        return "verbose_json" if self._model == self.DEFAULT_MODEL else "json"
 
     async def process_job(self) -> TranscriptionResult:
         downloaded_media_path = await self.manage_download()
         converted_media_path = await AudioHelper.convert_media_to_mp3(downloaded_media_path)
 
         size = await AudioHelper.get_size_mb(converted_media_path)
-
-        result = None
         if size > self.SIZE_LIMIT:
-            logger.info(f"Audio file is too large ({size} MB), splitting into smaller segments")
-            audio_segments = AudioHelper.split_audio(converted_media_path)
-            for audio_segment in audio_segments:
-                verbose_answer = await openai.Audio.atranscribe("whisper-1", audio_segment, response_format="verbose_json",
-                                                                prompt=self._prompt)
-                if result is None:
-                    result = TranscriptionResult(verbose_answer)
-                else:
-                    result.add_verbose_answer(verbose_answer)
+            logger.info("Audio file is too large (%s MB), splitting into smaller segments", size)
+            return await self.transcribe_chunks(converted_media_path)
 
-            print(result.get_json())
+        return await self.transcribe(self.get_file_path())
 
-        else:
-            result = await self.transcribe()
+    async def transcribe_chunks(self, file_path) -> TranscriptionResult:
+        audio_chunks = AudioHelper.split_audio(file_path, self.get_chunk_directory())
+        result = TranscriptionResult()
+        chunk_offset = 0.0
+        prior_text = ""
+
+        for audio_chunk in audio_chunks:
+            response = await self._transcribe_file(audio_chunk.path, prompt=prior_text)
+            result.append(
+                response,
+                start_offset=chunk_offset,
+                fallback_duration=audio_chunk.duration_seconds,
+            )
+            prior_text = result.get_plain_text()
+            chunk_offset += audio_chunk.duration_seconds
 
         return result
 
@@ -49,17 +82,19 @@ class VoiceJob(BaseJob):
         if not self._message.voice:
             raise TypeError("Message is not a voice message")
 
-        filename = self._id + ".ogg"
+        filename = f"{self._id}.ogg"
         client = self._client_handler
+        return await client.download_media(self._message, file=os.path.join(self._job_directory, filename))
 
-        return await client.download_media(self._message, file=self._job_directory + "/" + filename)
+    async def transcribe(self, file_path) -> TranscriptionResult:
+        response = await self._transcribe_file(file_path, prompt=self._prompt)
+        return TranscriptionResult.from_response(response)
 
-    async def transcribe(self) -> TranscriptionResult:
-
-        with open(self.get_file_path(), 'rb') as file:
-            verbose_answer = await openai.Audio.atranscribe("whisper-1", file, response_format="verbose_json",
-                                                            prompt=self._prompt)
-
-        result = TranscriptionResult(verbose_answer)
-
-        return result
+    async def _transcribe_file(self, file_path, prompt=""):
+        with open(file_path, "rb") as file:
+            return await openai.Audio.atranscribe(
+                self._model,
+                file,
+                response_format=self.get_response_format(),
+                prompt=prompt,
+            )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["setuptools>=75", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "telekit"
+version = "0.1.0"
+description = "Telegram self-automation client for voice transcription."
+readme = "README.md"
+requires-python = ">=3.10,<3.13"
+dependencies = [
+  "Typer==0.9.0",
+  "Telethon==1.29.2",
+  "cryptg==0.5.2",
+  "openai==0.27.8",
+  "python-dotenv>=1.0,<2.0",
+  "pydub>=0.25.1,<0.26",
+]
+
+[project.scripts]
+telekit = "app:app"
+
+[dependency-groups]
+dev = [
+  "pytest>=8.3,<9",
+]
+
+[tool.uv]
+default-groups = ["dev"]
+
+[tool.setuptools]
+py-modules = ["app", "control", "utils", "telekit_config"]
+
+[tool.setuptools.packages.find]
+include = ["commands*", "job_manager*"]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,14 @@ name = "telekit"
 version = "0.1.0"
 description = "Telegram self-automation client for voice transcription."
 readme = "README.md"
+# Telethon 1.29.x still imports stdlib modules removed in Python 3.13.
 requires-python = ">=3.10,<3.13"
 dependencies = [
   "Typer==0.9.0",
   "Telethon==1.29.2",
   "cryptg==0.5.2",
+  # Telekit still uses the pre-v1 openai.Audio.atranscribe client surface in
+  # job_manager/voice_job.py. Upgrading to OpenAI v1 requires a code migration.
   "openai==0.27.8",
   "python-dotenv>=1.0,<2.0",
   "pydub>=0.25.1,<0.26",
@@ -33,4 +36,3 @@ py-modules = ["app", "control", "utils", "telekit_config"]
 
 [tool.setuptools.packages.find]
 include = ["commands*", "job_manager*"]
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-Typer==0.9.0
-Telethon==1.29.2
-cryptg==0.2
-openai==0.27.8
+# Compatibility shim for users still running:
+#   pip install -r requirements.txt
+#
+# The canonical dependency declaration now lives in pyproject.toml.
+.

--- a/telekit_config.py
+++ b/telekit_config.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+DEFAULT_COMMANDS = ("IngTranscribeCommand", "IngGPTCommand")
+SUPPORTED_TRANSCRIPTION_MODELS = (
+    "whisper-1",
+    "gpt-4o-transcribe",
+    "gpt-4o-mini-transcribe",
+)
+
+
+@dataclass(frozen=True)
+class Settings:
+    root_dir: Path
+    data_dir: Path
+    clients_file: Path
+    sessions_dir: Path
+    jobs_dir: Path
+    api_id: str | None
+    api_hash: str | None
+    openai_api_key: str | None
+    transcription_model: str
+
+
+def load_settings(
+    *,
+    root_dir: Path | None = None,
+    data_dir: Path | None = None,
+    clients_file: Path | None = None,
+    sessions_dir: Path | None = None,
+    jobs_dir: Path | None = None,
+    transcription_model: str | None = None,
+) -> Settings:
+    root = (root_dir or Path.cwd()).resolve()
+    configured_data_dir = _resolve_path(
+        data_dir or os.getenv("TELEKIT_DATA_DIR") or "data",
+        root,
+    )
+    configured_clients_file = _resolve_path(
+        clients_file or os.getenv("TELEKIT_CLIENTS_FILE") or configured_data_dir / "clients.json",
+        root,
+    )
+    configured_sessions_dir = _resolve_path(
+        sessions_dir
+        or os.getenv("TELEKIT_SESSIONS_DIR")
+        or os.getenv("TELEKIT_SESSION_DIR")
+        or configured_data_dir / "sessions",
+        root,
+    )
+    configured_jobs_dir = _resolve_path(
+        jobs_dir or os.getenv("TELEKIT_JOBS_DIR") or "jobs",
+        root,
+    )
+    selected_model = transcription_model or os.getenv("TELEKIT_TRANSCRIPTION_MODEL") or "whisper-1"
+
+    return Settings(
+        root_dir=root,
+        data_dir=configured_data_dir,
+        clients_file=configured_clients_file,
+        sessions_dir=configured_sessions_dir,
+        jobs_dir=configured_jobs_dir,
+        api_id=os.getenv("API_ID"),
+        api_hash=os.getenv("API_HASH"),
+        openai_api_key=os.getenv("OPENAI_API_KEY"),
+        transcription_model=selected_model,
+    )
+
+
+def ensure_runtime_paths(settings: Settings) -> None:
+    settings.data_dir.mkdir(parents=True, exist_ok=True)
+    settings.sessions_dir.mkdir(parents=True, exist_ok=True)
+    settings.jobs_dir.mkdir(parents=True, exist_ok=True)
+    settings.clients_file.parent.mkdir(parents=True, exist_ok=True)
+    if not settings.clients_file.exists():
+        settings.clients_file.write_text("[]\n", encoding="utf-8")
+
+
+def validate_startup_settings(settings: Settings) -> list[str]:
+    missing = []
+    if not settings.api_id:
+        missing.append("API_ID")
+    if not settings.api_hash:
+        missing.append("API_HASH")
+    if not settings.openai_api_key:
+        missing.append("OPENAI_API_KEY")
+    if settings.transcription_model not in SUPPORTED_TRANSCRIPTION_MODELS:
+        missing.append(
+            "TELEKIT_TRANSCRIPTION_MODEL must be one of: "
+            + ", ".join(SUPPORTED_TRANSCRIPTION_MODELS)
+        )
+    return missing
+
+
+def _resolve_path(value: str | Path, root_dir: Path) -> Path:
+    path = Path(value)
+    if not path.is_absolute():
+        path = root_dir / path
+    return path.resolve()

--- a/telekit_config.py
+++ b/telekit_config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 import os
+import re
 
 from dotenv import load_dotenv
 
@@ -14,6 +15,7 @@ SUPPORTED_TRANSCRIPTION_MODELS = (
     "gpt-4o-transcribe",
     "gpt-4o-mini-transcribe",
 )
+SESSION_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
 @dataclass(frozen=True)
@@ -96,6 +98,19 @@ def validate_startup_settings(settings: Settings) -> list[str]:
             + ", ".join(SUPPORTED_TRANSCRIPTION_MODELS)
         )
     return missing
+
+
+def validate_session_name(session_name: str | None) -> str:
+    if not session_name:
+        raise ValueError("Session name cannot be empty.")
+    if Path(session_name).name != session_name or Path(session_name).is_absolute():
+        raise ValueError(f"Invalid session name: {session_name!r}")
+    if not SESSION_NAME_PATTERN.fullmatch(session_name):
+        raise ValueError(
+            "Invalid session name: "
+            f"{session_name!r}. Use only letters, numbers, hyphens, and underscores."
+        )
+    return session_name
 
 
 def _resolve_path(value: str | Path, root_dir: Path) -> Path:

--- a/tests/test_app_cli.py
+++ b/tests/test_app_cli.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from app import app
+
+
+runner = CliRunner()
+
+
+def test_add_client_creates_local_client_registry(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["add-client", "demo-session"])
+
+    assert result.exit_code == 0
+    clients_path = tmp_path / "data" / "clients.json"
+    assert clients_path.exists()
+    assert json.loads(clients_path.read_text(encoding="utf-8")) == [
+        {
+            "session_name": "demo-session",
+            "commands": ["IngTranscribeCommand", "IngGPTCommand"],
+        }
+    ]
+
+
+def test_help_explains_cli_surface():
+    result = runner.invoke(app, ["--help"])
+
+    assert result.exit_code == 0
+    assert "Telekit is a Telegram self-automation client" in result.stdout
+    assert "start-program" in result.stdout
+
+
+def test_start_program_help_mentions_transcription_model():
+    result = runner.invoke(app, ["start-program", "--help"])
+
+    assert result.exit_code == 0
+    assert "--transcription-model" in result.stdout
+    assert "gpt-4o-mini-" in result.stdout
+    assert "transcribe" in result.stdout

--- a/tests/test_app_cli.py
+++ b/tests/test_app_cli.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from typer.testing import CliRunner
 
-from app import app
+from app import app, load_client_data
 
 
 runner = CliRunner()
@@ -13,6 +13,11 @@ runner = CliRunner()
 
 def test_add_client_creates_local_client_registry(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("TELEKIT_DATA_DIR", raising=False)
+    monkeypatch.delenv("TELEKIT_CLIENTS_FILE", raising=False)
+    monkeypatch.delenv("TELEKIT_SESSIONS_DIR", raising=False)
+    monkeypatch.delenv("TELEKIT_SESSION_DIR", raising=False)
+    monkeypatch.delenv("TELEKIT_JOBS_DIR", raising=False)
 
     result = runner.invoke(app, ["add-client", "demo-session"])
 
@@ -25,6 +30,40 @@ def test_add_client_creates_local_client_registry(tmp_path, monkeypatch):
             "commands": ["IngTranscribeCommand", "IngGPTCommand"],
         }
     ]
+
+
+def test_add_client_rejects_duplicate_session(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("TELEKIT_DATA_DIR", raising=False)
+    monkeypatch.delenv("TELEKIT_CLIENTS_FILE", raising=False)
+    monkeypatch.delenv("TELEKIT_SESSIONS_DIR", raising=False)
+    monkeypatch.delenv("TELEKIT_SESSION_DIR", raising=False)
+    monkeypatch.delenv("TELEKIT_JOBS_DIR", raising=False)
+
+    assert runner.invoke(app, ["add-client", "demo-session"]).exit_code == 0
+    result = runner.invoke(app, ["add-client", "demo-session"])
+
+    assert result.exit_code == 2
+    assert "already registered" in result.stderr
+
+
+def test_load_client_data_rejects_malformed_registry(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("TELEKIT_DATA_DIR", raising=False)
+    monkeypatch.delenv("TELEKIT_CLIENTS_FILE", raising=False)
+    monkeypatch.delenv("TELEKIT_SESSIONS_DIR", raising=False)
+    monkeypatch.delenv("TELEKIT_SESSION_DIR", raising=False)
+    monkeypatch.delenv("TELEKIT_JOBS_DIR", raising=False)
+    clients_path = tmp_path / "data" / "clients.json"
+    clients_path.parent.mkdir(parents=True, exist_ok=True)
+    clients_path.write_text("{not valid json", encoding="utf-8")
+
+    try:
+        load_client_data(root_dir=tmp_path)
+    except ValueError as exc:
+        assert "Malformed client registry" in str(exc)
+    else:
+        raise AssertionError("Expected load_client_data to raise ValueError for malformed JSON")
 
 
 def test_help_explains_cli_surface():

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -19,7 +19,9 @@ def test_load_settings_uses_local_relative_paths(tmp_path, monkeypatch):
     monkeypatch.delenv("TELEKIT_DATA_DIR", raising=False)
     monkeypatch.delenv("TELEKIT_CLIENTS_FILE", raising=False)
     monkeypatch.delenv("TELEKIT_SESSIONS_DIR", raising=False)
+    monkeypatch.delenv("TELEKIT_SESSION_DIR", raising=False)
     monkeypatch.delenv("TELEKIT_JOBS_DIR", raising=False)
+    monkeypatch.delenv("TELEKIT_TRANSCRIPTION_MODEL", raising=False)
 
     settings = load_settings()
 
@@ -57,6 +59,7 @@ def test_validate_startup_settings_reports_missing_env(tmp_path, monkeypatch):
     monkeypatch.delenv("API_ID", raising=False)
     monkeypatch.delenv("API_HASH", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("TELEKIT_TRANSCRIPTION_MODEL", raising=False)
 
     errors = validate_startup_settings(load_settings())
 
@@ -78,3 +81,35 @@ def test_client_factory_uses_configured_sessions_directory(tmp_path, monkeypatch
     assert handler.client.session_path == str((tmp_path / "data" / "sessions" / "demo.session").resolve())
     assert handler.client.api_id == "123"
     assert handler.client.api_hash == "hash"
+
+
+def test_client_factory_rejects_invalid_session_name(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("API_ID", "123")
+    monkeypatch.setenv("API_HASH", "hash")
+
+    try:
+        ClientFactory.create_client(
+            {"session_name": "../escape", "commands": ["IngGPTCommand"]},
+            settings=load_settings(),
+        )
+    except ValueError as exc:
+        assert "Invalid session name" in str(exc)
+    else:
+        raise AssertionError("Expected invalid session name to be rejected")
+
+
+def test_client_factory_rejects_unknown_command(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("API_ID", "123")
+    monkeypatch.setenv("API_HASH", "hash")
+
+    try:
+        ClientFactory.create_client(
+            {"session_name": "demo", "commands": ["NopeCommand"]},
+            settings=load_settings(),
+        )
+    except ValueError as exc:
+        assert "Unknown command" in str(exc)
+    else:
+        raise AssertionError("Expected unknown commands to be rejected")

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from telekit_config import ensure_runtime_paths, load_settings, validate_startup_settings
+from control import ClientFactory
+
+
+class DummyTelegramClient:
+    def __init__(self, session_path, api_id, api_hash):
+        self.session_path = session_path
+        self.api_id = api_id
+        self.api_hash = api_hash
+        self.parse_mode = None
+
+
+def test_load_settings_uses_local_relative_paths(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("TELEKIT_DATA_DIR", raising=False)
+    monkeypatch.delenv("TELEKIT_CLIENTS_FILE", raising=False)
+    monkeypatch.delenv("TELEKIT_SESSIONS_DIR", raising=False)
+    monkeypatch.delenv("TELEKIT_JOBS_DIR", raising=False)
+
+    settings = load_settings()
+
+    assert settings.data_dir == (tmp_path / "data").resolve()
+    assert settings.clients_file == (tmp_path / "data" / "clients.json").resolve()
+    assert settings.sessions_dir == (tmp_path / "data" / "sessions").resolve()
+    assert settings.jobs_dir == (tmp_path / "jobs").resolve()
+
+
+def test_ensure_runtime_paths_creates_expected_directories(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    settings = load_settings()
+
+    ensure_runtime_paths(settings)
+
+    assert settings.data_dir.is_dir()
+    assert settings.sessions_dir.is_dir()
+    assert settings.jobs_dir.is_dir()
+    assert settings.clients_file.exists()
+    assert settings.clients_file.read_text(encoding="utf-8").strip() == "[]"
+
+
+def test_load_settings_accepts_singular_session_dir_env_alias(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("TELEKIT_SESSIONS_DIR", raising=False)
+    monkeypatch.setenv("TELEKIT_SESSION_DIR", "./custom-sessions")
+
+    settings = load_settings()
+
+    assert settings.sessions_dir == (tmp_path / "custom-sessions").resolve()
+
+
+def test_validate_startup_settings_reports_missing_env(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("API_ID", raising=False)
+    monkeypatch.delenv("API_HASH", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    errors = validate_startup_settings(load_settings())
+
+    assert errors == ["API_ID", "API_HASH", "OPENAI_API_KEY"]
+
+
+def test_client_factory_uses_configured_sessions_directory(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("API_ID", "123")
+    monkeypatch.setenv("API_HASH", "hash")
+    monkeypatch.setattr("control.TelegramClient", DummyTelegramClient)
+
+    settings = load_settings()
+    handler = ClientFactory.create_client(
+        {"session_name": "demo", "commands": ["IngGPTCommand"]},
+        settings=settings,
+    )
+
+    assert handler.client.session_path == str((tmp_path / "data" / "sessions" / "demo.session").resolve())
+    assert handler.client.api_id == "123"
+    assert handler.client.api_hash == "hash"

--- a/tests/test_transcription_flow.py
+++ b/tests/test_transcription_flow.py
@@ -1,0 +1,197 @@
+import datetime
+import os
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from control import ClientHandler
+from commands.ing_transcribe.ing_transcribe import IngTranscribeCommand
+from job_manager.transcription_result import TranscriptionResult
+from job_manager.voice_job import VoiceJob
+from utils import AudioChunk
+
+
+class FakeClient:
+    def __init__(self):
+        self.parse_mode = None
+        self.edits = []
+        self.messages = []
+
+    async def edit_message(self, peer_id, message_id, new_text, **kwargs):
+        self.edits.append((peer_id, message_id, new_text, kwargs))
+
+    async def send_message(self, peer_id, message, **kwargs):
+        self.messages.append((peer_id, message, kwargs))
+
+
+class DummyClientHandler:
+    def __init__(self, downloaded_path):
+        self.downloaded_path = downloaded_path
+
+    async def download_media(self, message, file, progress_callback=None):
+        return self.downloaded_path
+
+
+class TranscriptionResultTests(unittest.TestCase):
+    def test_whisper_verbose_json_keeps_segments(self):
+        result = TranscriptionResult.from_response(
+            {
+                "duration": 2.0,
+                "segments": [
+                    {"start": 0.0, "text": " Hello"},
+                    {"start": 1.2, "text": " world"},
+                ],
+            }
+        )
+
+        self.assertTrue(result.supports_timestamps())
+        self.assertEqual("Hello world", result.get_plain_text())
+        self.assertEqual(
+            [
+                {"start": 0.0, "text": " Hello"},
+                {"start": 1.2, "text": " world"},
+            ],
+            result.get_segments(),
+        )
+
+    def test_gpt_json_falls_back_to_plain_text_segment(self):
+        result = TranscriptionResult.from_response({"text": "Plain transcript"}, start_offset=5.0)
+
+        self.assertFalse(result.supports_timestamps())
+        self.assertEqual("Plain transcript", result.get_plain_text())
+        self.assertEqual([{"start": 5.0, "text": "Plain transcript"}], result.get_segments())
+
+    def test_append_preserves_offsets(self):
+        result = TranscriptionResult.from_response(
+            {"duration": 1.0, "segments": [{"start": 0.0, "text": " One"}]}
+        )
+        result.append(
+            {"duration": 1.0, "segments": [{"start": 0.0, "text": " two"}]},
+            start_offset=1.5,
+        )
+
+        self.assertEqual(
+            [
+                {"start": 0.0, "text": " One"},
+                {"start": 1.5, "text": " two"},
+            ],
+            result.get_segments(),
+        )
+
+
+class VoiceJobTests(unittest.IsolatedAsyncioTestCase):
+    async def test_long_audio_path_uses_real_chunk_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            original_path = os.path.join(tmpdir, "sample.ogg")
+            converted_path = os.path.join(tmpdir, "sample.mp3")
+            chunk_one = os.path.join(tmpdir, "chunk-1.mp3")
+            chunk_two = os.path.join(tmpdir, "chunk-2.mp3")
+
+            for path in (original_path, converted_path, chunk_one, chunk_two):
+                with open(path, "wb") as handle:
+                    handle.write(b"test")
+
+            handler = DummyClientHandler(original_path)
+            message = SimpleNamespace(voice=True)
+            job = VoiceJob(handler, message, model="gpt-4o-mini-transcribe")
+
+            responses = [{"text": "First"}, {"text": " second"}]
+            mock_transcribe = AsyncMock(side_effect=responses)
+
+            with patch("job_manager.voice_job.AudioHelper.convert_media_to_mp3", AsyncMock(return_value=converted_path)), \
+                patch("job_manager.voice_job.AudioHelper.get_size_mb", AsyncMock(return_value=25)), \
+                patch(
+                    "job_manager.voice_job.AudioHelper.split_audio",
+                    return_value=[
+                        AudioChunk(path=chunk_one, duration_seconds=3.0),
+                        AudioChunk(path=chunk_two, duration_seconds=2.0),
+                    ],
+                ), \
+                patch("job_manager.voice_job.openai.Audio.atranscribe", mock_transcribe):
+                result = await job.process_job()
+
+            self.assertEqual("First second", result.get_plain_text())
+            self.assertFalse(result.supports_timestamps())
+            self.assertEqual(chunk_one, mock_transcribe.await_args_list[0].args[1].name)
+            self.assertEqual(chunk_two, mock_transcribe.await_args_list[1].args[1].name)
+
+    async def test_model_resolution_prefers_env_then_falls_back(self):
+        message = SimpleNamespace(voice=True)
+        handler = DummyClientHandler("/tmp/sample.ogg")
+
+        with patch.dict(os.environ, {"TELEKIT_TRANSCRIPTION_MODEL": "gpt-4o-transcribe"}, clear=False):
+            job = VoiceJob(handler, message)
+            self.assertEqual("gpt-4o-transcribe", job._model)
+
+        with patch.dict(os.environ, {"TELEKIT_TRANSCRIPTION_MODEL": "not-a-real-model"}, clear=False):
+            job = VoiceJob(handler, message)
+            self.assertEqual(VoiceJob.DEFAULT_MODEL, job._model)
+
+
+class ClientHandlerTranscriptTests(unittest.IsolatedAsyncioTestCase):
+    async def test_send_transcript_splits_long_edit_into_edit_and_replies(self):
+        client = FakeClient()
+        handler = ClientHandler(client, [])
+        text = "word " * 1200
+
+        await handler.send_transcript(
+            peer_id=1,
+            text=text,
+            edit_message_id=42,
+            reply_to=42,
+            prepend_message="prefix\n\n",
+            prefer_edit=True,
+        )
+
+        self.assertEqual(1, len(client.edits))
+        self.assertGreaterEqual(len(client.messages), 1)
+        self.assertTrue(client.edits[0][2].startswith("prefix"))
+
+    async def test_send_transcript_replies_for_media_overflow_instead_of_file(self):
+        client = FakeClient()
+        handler = ClientHandler(client, [])
+        text = "word " * 1200
+
+        await handler.send_transcript(
+            peer_id=1,
+            text=text,
+            edit_message_id=99,
+            reply_to=99,
+            prepend_message="prefix\n\n",
+            prefer_edit=True,
+            is_media_message=True,
+        )
+
+        self.assertEqual(1, len(client.edits))
+        self.assertIn("Transcription continues below.", client.edits[0][2])
+        self.assertGreaterEqual(len(client.messages), 1)
+
+
+class IngTranscribeCommandTests(unittest.IsolatedAsyncioTestCase):
+    async def test_client_settings_model_is_used_when_flag_is_absent(self):
+        event = SimpleNamespace(
+            message=SimpleNamespace(
+                peer_id=1,
+                voice=True,
+                id=10,
+                date=datetime.datetime.now(datetime.timezone.utc),
+            )
+        )
+        client_handler = SimpleNamespace(
+            settings=SimpleNamespace(transcription_model="gpt-4o-mini-transcribe"),
+            edit_message=AsyncMock(),
+        )
+        command = IngTranscribeCommand(event, client_handler)
+        fake_result = SimpleNamespace(get_plain_text=lambda: "done")
+
+        with patch("commands.ing_transcribe.ing_transcribe.VoiceJob") as mock_voice_job, \
+            patch.object(command, "send_result", AsyncMock()):
+            mock_voice_job.return_value.process_job = AsyncMock(return_value=fake_result)
+            await command.handle_voice_message()
+
+        assert mock_voice_job.call_args.kwargs["model"] == "gpt-4o-mini-transcribe"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_transcription_flow.py
+++ b/tests/test_transcription_flow.py
@@ -118,15 +118,36 @@ class VoiceJobTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_model_resolution_prefers_env_then_falls_back(self):
         message = SimpleNamespace(voice=True)
-        handler = DummyClientHandler("/tmp/sample.ogg")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            handler = DummyClientHandler(os.path.join(tmpdir, "sample.ogg"))
 
-        with patch.dict(os.environ, {"TELEKIT_TRANSCRIPTION_MODEL": "gpt-4o-transcribe"}, clear=False):
-            job = VoiceJob(handler, message)
-            self.assertEqual("gpt-4o-transcribe", job._model)
+            with patch.dict(os.environ, {"TELEKIT_TRANSCRIPTION_MODEL": "gpt-4o-transcribe"}, clear=False):
+                job = VoiceJob(handler, message)
+                self.assertEqual("gpt-4o-transcribe", job._model)
 
-        with patch.dict(os.environ, {"TELEKIT_TRANSCRIPTION_MODEL": "not-a-real-model"}, clear=False):
-            job = VoiceJob(handler, message)
-            self.assertEqual(VoiceJob.DEFAULT_MODEL, job._model)
+            with patch.dict(os.environ, {"TELEKIT_TRANSCRIPTION_MODEL": "not-a-real-model"}, clear=False):
+                job = VoiceJob(handler, message)
+                self.assertEqual(VoiceJob.DEFAULT_MODEL, job._model)
+
+    async def test_small_audio_path_uses_converted_mp3(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            original_path = os.path.join(tmpdir, "sample.ogg")
+            converted_path = os.path.join(tmpdir, "sample.mp3")
+            for path in (original_path, converted_path):
+                with open(path, "wb") as handle:
+                    handle.write(b"test")
+
+            handler = DummyClientHandler(original_path)
+            message = SimpleNamespace(voice=True)
+            job = VoiceJob(handler, message, model="gpt-4o-mini-transcribe")
+            mock_transcribe = AsyncMock(return_value={"text": "done"})
+
+            with patch("job_manager.voice_job.AudioHelper.convert_media_to_mp3", AsyncMock(return_value=converted_path)), \
+                patch("job_manager.voice_job.AudioHelper.get_size_mb", AsyncMock(return_value=1)), \
+                patch("job_manager.voice_job.openai.Audio.atranscribe", mock_transcribe):
+                await job.process_job()
+
+            self.assertEqual(converted_path, mock_transcribe.await_args.args[1].name)
 
 
 class ClientHandlerTranscriptTests(unittest.IsolatedAsyncioTestCase):
@@ -190,7 +211,7 @@ class IngTranscribeCommandTests(unittest.IsolatedAsyncioTestCase):
             mock_voice_job.return_value.process_job = AsyncMock(return_value=fake_result)
             await command.handle_voice_message()
 
-        assert mock_voice_job.call_args.kwargs["model"] == "gpt-4o-mini-transcribe"
+        self.assertEqual(mock_voice_job.call_args.kwargs["model"], "gpt-4o-mini-transcribe")
 
 
 if __name__ == "__main__":

--- a/utils.py
+++ b/utils.py
@@ -1,43 +1,54 @@
 import math
 import os
+from dataclasses import dataclass
 
 from pydub import AudioSegment
+from telethon import types
+from telethon.extensions import markdown
+
+
+@dataclass
+class AudioChunk:
+    path: str
+    duration_seconds: float
 
 
 class AudioHelper:
     @staticmethod
     async def convert_media_to_mp3(file_path):
         input_format = os.path.splitext(file_path)[1][1:]
-        output_path = os.path.splitext(file_path)[0] + '.mp3'
-        AudioSegment.from_file(file_path, input_format).export(output_path, format='mp3')
+        output_path = os.path.splitext(file_path)[0] + ".mp3"
+        AudioSegment.from_file(file_path, input_format).export(output_path, format="mp3")
         return output_path
 
     @staticmethod
     async def get_size_mb(file_path):
         size_in_bytes = os.path.getsize(file_path)
-        size_in_mb = size_in_bytes / (1024 * 1024)
-        return size_in_mb
+        return size_in_bytes / (1024 * 1024)
 
     @staticmethod
-    def split_audio(file_path, max_size=2) -> list[AudioSegment]:
+    def split_audio(file_path, output_dir, max_size_mb=2) -> list[AudioChunk]:
         audio = AudioSegment.from_mp3(file_path)
+        os.makedirs(output_dir, exist_ok=True)
 
-        duration = len(audio)
-        fragment_duration = math.ceil(
-            (max_size * 1000 * 1024 * 1024) / audio.frame_rate / audio.sample_width / audio.channels)
-        fragments = []
+        bytes_per_ms = audio.frame_rate * audio.sample_width * audio.channels / 1000
+        fragment_duration_ms = max(1, math.floor((max_size_mb * 1024 * 1024) / bytes_per_ms))
+
+        chunks = []
         start = 0
+        index = 0
+        duration = len(audio)
 
         while start < duration:
-            end = min(start + fragment_duration, duration)
-            fragments.append(audio[start:end])
+            end = min(start + fragment_duration_ms, duration)
+            chunk = audio[start:end]
+            chunk_path = os.path.join(output_dir, f"chunk_{index:03d}.mp3")
+            chunk.export(chunk_path, format="mp3")
+            chunks.append(AudioChunk(path=chunk_path, duration_seconds=len(chunk) / 1000))
             start = end
+            index += 1
 
-        return fragments
-
-
-from telethon.extensions import markdown
-from telethon import types
+        return chunks
 
 
 class CustomMarkdown:
@@ -46,17 +57,17 @@ class CustomMarkdown:
         text, entities = markdown.parse(text)
         for i, e in enumerate(entities):
             if isinstance(e, types.MessageEntityTextUrl):
-                if e.url == 'spoiler':
+                if e.url == "spoiler":
                     entities[i] = types.MessageEntitySpoiler(e.offset, e.length)
-                elif e.url.startswith('emoji/'):
-                    entities[i] = types.MessageEntityCustomEmoji(e.offset, e.length, int(e.url.split('/')[1]))
+                elif e.url.startswith("emoji/"):
+                    entities[i] = types.MessageEntityCustomEmoji(e.offset, e.length, int(e.url.split("/")[1]))
         return text, entities
 
     @staticmethod
     def unparse(text, entities):
         for i, e in enumerate(entities or []):
             if isinstance(e, types.MessageEntityCustomEmoji):
-                entities[i] = types.MessageEntityTextUrl(e.offset, e.length, f'emoji/{e.document_id}')
+                entities[i] = types.MessageEntityTextUrl(e.offset, e.length, f"emoji/{e.document_id}")
             if isinstance(e, types.MessageEntitySpoiler):
-                entities[i] = types.MessageEntityTextUrl(e.offset, e.length, 'spoiler')
+                entities[i] = types.MessageEntityTextUrl(e.offset, e.length, "spoiler")
         return markdown.unparse(text, entities)

--- a/utils.py
+++ b/utils.py
@@ -14,11 +14,17 @@ class AudioChunk:
 
 
 class AudioHelper:
+    MP3_EXPORT_BITRATE = "64k"
+
     @staticmethod
     async def convert_media_to_mp3(file_path):
         input_format = os.path.splitext(file_path)[1][1:]
         output_path = os.path.splitext(file_path)[0] + ".mp3"
-        AudioSegment.from_file(file_path, input_format).export(output_path, format="mp3")
+        AudioSegment.from_file(file_path, input_format).export(
+            output_path,
+            format="mp3",
+            bitrate=AudioHelper.MP3_EXPORT_BITRATE,
+        )
         return output_path
 
     @staticmethod
@@ -31,7 +37,7 @@ class AudioHelper:
         audio = AudioSegment.from_mp3(file_path)
         os.makedirs(output_dir, exist_ok=True)
 
-        bytes_per_ms = audio.frame_rate * audio.sample_width * audio.channels / 1000
+        bytes_per_ms = AudioHelper._bitrate_bytes_per_ms(AudioHelper.MP3_EXPORT_BITRATE)
         fragment_duration_ms = max(1, math.floor((max_size_mb * 1024 * 1024) / bytes_per_ms))
 
         chunks = []
@@ -43,12 +49,27 @@ class AudioHelper:
             end = min(start + fragment_duration_ms, duration)
             chunk = audio[start:end]
             chunk_path = os.path.join(output_dir, f"chunk_{index:03d}.mp3")
-            chunk.export(chunk_path, format="mp3")
+            chunk.export(
+                chunk_path,
+                format="mp3",
+                bitrate=AudioHelper.MP3_EXPORT_BITRATE,
+            )
             chunks.append(AudioChunk(path=chunk_path, duration_seconds=len(chunk) / 1000))
             start = end
             index += 1
 
         return chunks
+
+    @staticmethod
+    def _bitrate_bytes_per_ms(bitrate: str) -> float:
+        normalized = bitrate.strip().lower()
+        if normalized.endswith("k"):
+            bits_per_second = int(normalized[:-1]) * 1000
+        elif normalized.endswith("m"):
+            bits_per_second = int(normalized[:-1]) * 1_000_000
+        else:
+            bits_per_second = int(normalized)
+        return bits_per_second / 8 / 1000
 
 
 class CustomMarkdown:

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,735 @@
+version = 1
+revision = 3
+requires-python = ">=3.10, <3.13"
+
+[[package]]
+name = "aiohappyeyeballs"
+version = "2.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/30/f84a107a9c4331c14b2b586036f40965c128aa4fee4dda5d3d51cb14ad54/aiohappyeyeballs-2.6.1.tar.gz", hash = "sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558", size = 22760, upload-time = "2025-03-12T01:42:48.764Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl", hash = "sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8", size = 15265, upload-time = "2025-03-12T01:42:47.083Z" },
+]
+
+[[package]]
+name = "aiohttp"
+version = "3.13.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohappyeyeballs" },
+    { name = "aiosignal" },
+    { name = "async-timeout", marker = "python_full_version < '3.11'" },
+    { name = "attrs" },
+    { name = "frozenlist" },
+    { name = "multidict" },
+    { name = "propcache" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/42/32cf8e7704ceb4481406eb87161349abb46a57fee3f008ba9cb610968646/aiohttp-3.13.3.tar.gz", hash = "sha256:a949eee43d3782f2daae4f4a2819b2cb9b0c5d3b7f7a927067cc84dafdbb9f88", size = 7844556, upload-time = "2026-01-03T17:33:05.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/d6/5aec9313ee6ea9c7cde8b891b69f4ff4001416867104580670a31daeba5b/aiohttp-3.13.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d5a372fd5afd301b3a89582817fdcdb6c34124787c70dbcc616f259013e7eef7", size = 738950, upload-time = "2026-01-03T17:29:13.002Z" },
+    { url = "https://files.pythonhosted.org/packages/68/03/8fa90a7e6d11ff20a18837a8e2b5dd23db01aabc475aa9271c8ad33299f5/aiohttp-3.13.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:147e422fd1223005c22b4fe080f5d93ced44460f5f9c105406b753612b587821", size = 496099, upload-time = "2026-01-03T17:29:15.268Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/b81f744d402510a8366b74eb420fc0cc1170d0c43daca12d10814df85f10/aiohttp-3.13.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:859bd3f2156e81dd01432f5849fc73e2243d4a487c4fd26609b1299534ee1845", size = 491072, upload-time = "2026-01-03T17:29:16.922Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e1/56d1d1c0dd334cd203dd97706ce004c1aa24b34a813b0b8daf3383039706/aiohttp-3.13.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dca68018bf48c251ba17c72ed479f4dafe9dbd5a73707ad8d28a38d11f3d42af", size = 1671588, upload-time = "2026-01-03T17:29:18.539Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/34/8d7f962604f4bc2b4e39eb1220dac7d4e4cba91fb9ba0474b4ecd67db165/aiohttp-3.13.3-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:fee0c6bc7db1de362252affec009707a17478a00ec69f797d23ca256e36d5940", size = 1640334, upload-time = "2026-01-03T17:29:21.028Z" },
+    { url = "https://files.pythonhosted.org/packages/94/1d/fcccf2c668d87337ddeef9881537baee13c58d8f01f12ba8a24215f2b804/aiohttp-3.13.3-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c048058117fd649334d81b4b526e94bde3ccaddb20463a815ced6ecbb7d11160", size = 1722656, upload-time = "2026-01-03T17:29:22.531Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/98/c6f3b081c4c606bc1e5f2ec102e87d6411c73a9ef3616fea6f2d5c98c062/aiohttp-3.13.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:215a685b6fbbfcf71dfe96e3eba7a6f58f10da1dfdf4889c7dd856abe430dca7", size = 1817625, upload-time = "2026-01-03T17:29:24.276Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c0/cfcc3d2e11b477f86e1af2863f3858c8850d751ce8dc39c4058a072c9e54/aiohttp-3.13.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:de2c184bb1fe2cbd2cefba613e9db29a5ab559323f994b6737e370d3da0ac455", size = 1672604, upload-time = "2026-01-03T17:29:26.099Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/77/6b4ffcbcac4c6a5d041343a756f34a6dd26174ae07f977a64fe028dda5b0/aiohttp-3.13.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:75ca857eba4e20ce9f546cd59c7007b33906a4cd48f2ff6ccf1ccfc3b646f279", size = 1554370, upload-time = "2026-01-03T17:29:28.121Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f0/e3ddfa93f17d689dbe014ba048f18e0c9f9b456033b70e94349a2e9048be/aiohttp-3.13.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:81e97251d9298386c2b7dbeb490d3d1badbdc69107fb8c9299dd04eb39bddc0e", size = 1642023, upload-time = "2026-01-03T17:29:30.002Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/45/c14019c9ec60a8e243d06d601b33dcc4fd92379424bde3021725859d7f99/aiohttp-3.13.3-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:c0e2d366af265797506f0283487223146af57815b388623f0357ef7eac9b209d", size = 1649680, upload-time = "2026-01-03T17:29:31.782Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/fd/09c9451dae5aa5c5ed756df95ff9ef549d45d4be663bafd1e4954fd836f0/aiohttp-3.13.3-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:4e239d501f73d6db1522599e14b9b321a7e3b1de66ce33d53a765d975e9f4808", size = 1692407, upload-time = "2026-01-03T17:29:33.392Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/81/938bc2ec33c10efd6637ccb3d22f9f3160d08e8f3aa2587a2c2d5ab578eb/aiohttp-3.13.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:0db318f7a6f065d84cb1e02662c526294450b314a02bd9e2a8e67f0d8564ce40", size = 1543047, upload-time = "2026-01-03T17:29:34.855Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/23/80488ee21c8d567c83045e412e1d9b7077d27171591a4eb7822586e8c06a/aiohttp-3.13.3-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:bfc1cc2fe31a6026a8a88e4ecfb98d7f6b1fec150cfd708adbfd1d2f42257c29", size = 1715264, upload-time = "2026-01-03T17:29:36.389Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/83/259a8da6683182768200b368120ab3deff5370bed93880fb9a3a86299f34/aiohttp-3.13.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:af71fff7bac6bb7508956696dce8f6eec2bbb045eceb40343944b1ae62b5ef11", size = 1657275, upload-time = "2026-01-03T17:29:38.162Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/4f/2c41f800a0b560785c10fb316216ac058c105f9be50bdc6a285de88db625/aiohttp-3.13.3-cp310-cp310-win32.whl", hash = "sha256:37da61e244d1749798c151421602884db5270faf479cf0ef03af0ff68954c9dd", size = 434053, upload-time = "2026-01-03T17:29:40.074Z" },
+    { url = "https://files.pythonhosted.org/packages/80/df/29cd63c7ecfdb65ccc12f7d808cac4fa2a19544660c06c61a4a48462de0c/aiohttp-3.13.3-cp310-cp310-win_amd64.whl", hash = "sha256:7e63f210bc1b57ef699035f2b4b6d9ce096b5914414a49b0997c839b2bd2223c", size = 456687, upload-time = "2026-01-03T17:29:41.819Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/4c/a164164834f03924d9a29dc3acd9e7ee58f95857e0b467f6d04298594ebb/aiohttp-3.13.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:5b6073099fb654e0a068ae678b10feff95c5cae95bbfcbfa7af669d361a8aa6b", size = 746051, upload-time = "2026-01-03T17:29:43.287Z" },
+    { url = "https://files.pythonhosted.org/packages/82/71/d5c31390d18d4f58115037c432b7e0348c60f6f53b727cad33172144a112/aiohttp-3.13.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cb93e166e6c28716c8c6aeb5f99dfb6d5ccf482d29fe9bf9a794110e6d0ab64", size = 499234, upload-time = "2026-01-03T17:29:44.822Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/c9/741f8ac91e14b1d2e7100690425a5b2b919a87a5075406582991fb7de920/aiohttp-3.13.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:28e027cf2f6b641693a09f631759b4d9ce9165099d2b5d92af9bd4e197690eea", size = 494979, upload-time = "2026-01-03T17:29:46.405Z" },
+    { url = "https://files.pythonhosted.org/packages/75/b5/31d4d2e802dfd59f74ed47eba48869c1c21552c586d5e81a9d0d5c2ad640/aiohttp-3.13.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3b61b7169ababd7802f9568ed96142616a9118dd2be0d1866e920e77ec8fa92a", size = 1748297, upload-time = "2026-01-03T17:29:48.083Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/3e/eefad0ad42959f226bb79664826883f2687d602a9ae2941a18e0484a74d3/aiohttp-3.13.3-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:80dd4c21b0f6237676449c6baaa1039abae86b91636b6c91a7f8e61c87f89540", size = 1707172, upload-time = "2026-01-03T17:29:49.648Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/3a/54a64299fac2891c346cdcf2aa6803f994a2e4beeaf2e5a09dcc54acc842/aiohttp-3.13.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:65d2ccb7eabee90ce0503c17716fc77226be026dcc3e65cce859a30db715025b", size = 1805405, upload-time = "2026-01-03T17:29:51.244Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/70/ddc1b7169cf64075e864f64595a14b147a895a868394a48f6a8031979038/aiohttp-3.13.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5b179331a481cb5529fca8b432d8d3c7001cb217513c94cd72d668d1248688a3", size = 1899449, upload-time = "2026-01-03T17:29:53.938Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/7e/6815aab7d3a56610891c76ef79095677b8b5be6646aaf00f69b221765021/aiohttp-3.13.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d4c940f02f49483b18b079d1c27ab948721852b281f8b015c058100e9421dd1", size = 1748444, upload-time = "2026-01-03T17:29:55.484Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/f2/073b145c4100da5511f457dc0f7558e99b2987cf72600d42b559db856fbc/aiohttp-3.13.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f9444f105664c4ce47a2a7171a2418bce5b7bae45fb610f4e2c36045d85911d3", size = 1606038, upload-time = "2026-01-03T17:29:57.179Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/c1/778d011920cae03ae01424ec202c513dc69243cf2db303965615b81deeea/aiohttp-3.13.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:694976222c711d1d00ba131904beb60534f93966562f64440d0c9d41b8cdb440", size = 1724156, upload-time = "2026-01-03T17:29:58.914Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/cb/3419eabf4ec1e9ec6f242c32b689248365a1cf621891f6f0386632525494/aiohttp-3.13.3-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:f33ed1a2bf1997a36661874b017f5c4b760f41266341af36febaf271d179f6d7", size = 1722340, upload-time = "2026-01-03T17:30:01.962Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/e5/76cf77bdbc435bf233c1f114edad39ed4177ccbfab7c329482b179cff4f4/aiohttp-3.13.3-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:e636b3c5f61da31a92bf0d91da83e58fdfa96f178ba682f11d24f31944cdd28c", size = 1783041, upload-time = "2026-01-03T17:30:03.609Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/d4/dd1ca234c794fd29c057ce8c0566b8ef7fd6a51069de5f06fa84b9a1971c/aiohttp-3.13.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:5d2d94f1f5fcbe40838ac51a6ab5704a6f9ea42e72ceda48de5e6b898521da51", size = 1596024, upload-time = "2026-01-03T17:30:05.132Z" },
+    { url = "https://files.pythonhosted.org/packages/55/58/4345b5f26661a6180afa686c473620c30a66afdf120ed3dd545bbc809e85/aiohttp-3.13.3-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:2be0e9ccf23e8a94f6f0650ce06042cefc6ac703d0d7ab6c7a917289f2539ad4", size = 1804590, upload-time = "2026-01-03T17:30:07.135Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/06/05950619af6c2df7e0a431d889ba2813c9f0129cec76f663e547a5ad56f2/aiohttp-3.13.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9af5e68ee47d6534d36791bbe9b646d2a7c7deb6fc24d7943628edfbb3581f29", size = 1740355, upload-time = "2026-01-03T17:30:09.083Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/80/958f16de79ba0422d7c1e284b2abd0c84bc03394fbe631d0a39ffa10e1eb/aiohttp-3.13.3-cp311-cp311-win32.whl", hash = "sha256:a2212ad43c0833a873d0fb3c63fa1bacedd4cf6af2fee62bf4b739ceec3ab239", size = 433701, upload-time = "2026-01-03T17:30:10.869Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/f2/27cdf04c9851712d6c1b99df6821a6623c3c9e55956d4b1e318c337b5a48/aiohttp-3.13.3-cp311-cp311-win_amd64.whl", hash = "sha256:642f752c3eb117b105acbd87e2c143de710987e09860d674e068c4c2c441034f", size = 457678, upload-time = "2026-01-03T17:30:12.719Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/be/4fc11f202955a69e0db803a12a062b8379c970c7c84f4882b6da17337cc1/aiohttp-3.13.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b903a4dfee7d347e2d87697d0713be59e0b87925be030c9178c5faa58ea58d5c", size = 739732, upload-time = "2026-01-03T17:30:14.23Z" },
+    { url = "https://files.pythonhosted.org/packages/97/2c/621d5b851f94fa0bb7430d6089b3aa970a9d9b75196bc93bb624b0db237a/aiohttp-3.13.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a45530014d7a1e09f4a55f4f43097ba0fd155089372e105e4bff4ca76cb1b168", size = 494293, upload-time = "2026-01-03T17:30:15.96Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/43/4be01406b78e1be8320bb8316dc9c42dbab553d281c40364e0f862d5661c/aiohttp-3.13.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:27234ef6d85c914f9efeb77ff616dbf4ad2380be0cda40b4db086ffc7ddd1b7d", size = 493533, upload-time = "2026-01-03T17:30:17.431Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a8/5a35dc56a06a2c90d4742cbf35294396907027f80eea696637945a106f25/aiohttp-3.13.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d32764c6c9aafb7fb55366a224756387cd50bfa720f32b88e0e6fa45b27dcf29", size = 1737839, upload-time = "2026-01-03T17:30:19.422Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/62/4b9eeb331da56530bf2e198a297e5303e1c1ebdceeb00fe9b568a65c5a0c/aiohttp-3.13.3-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:b1a6102b4d3ebc07dad44fbf07b45bb600300f15b552ddf1851b5390202ea2e3", size = 1703932, upload-time = "2026-01-03T17:30:21.756Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f6/af16887b5d419e6a367095994c0b1332d154f647e7dc2bd50e61876e8e3d/aiohttp-3.13.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c014c7ea7fb775dd015b2d3137378b7be0249a448a1612268b5a90c2d81de04d", size = 1771906, upload-time = "2026-01-03T17:30:23.932Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/83/397c634b1bcc24292fa1e0c7822800f9f6569e32934bdeef09dae7992dfb/aiohttp-3.13.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2b8d8ddba8f95ba17582226f80e2de99c7a7948e66490ef8d947e272a93e9463", size = 1871020, upload-time = "2026-01-03T17:30:26Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f6/a62cbbf13f0ac80a70f71b1672feba90fdb21fd7abd8dbf25c0105fb6fa3/aiohttp-3.13.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9ae8dd55c8e6c4257eae3a20fd2c8f41edaea5992ed67156642493b8daf3cecc", size = 1755181, upload-time = "2026-01-03T17:30:27.554Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/87/20a35ad487efdd3fba93d5843efdfaa62d2f1479eaafa7453398a44faf13/aiohttp-3.13.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:01ad2529d4b5035578f5081606a465f3b814c542882804e2e8cda61adf5c71bf", size = 1561794, upload-time = "2026-01-03T17:30:29.254Z" },
+    { url = "https://files.pythonhosted.org/packages/de/95/8fd69a66682012f6716e1bc09ef8a1a2a91922c5725cb904689f112309c4/aiohttp-3.13.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bb4f7475e359992b580559e008c598091c45b5088f28614e855e42d39c2f1033", size = 1697900, upload-time = "2026-01-03T17:30:31.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/66/7b94b3b5ba70e955ff597672dad1691333080e37f50280178967aff68657/aiohttp-3.13.3-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:c19b90316ad3b24c69cd78d5c9b4f3aa4497643685901185b65166293d36a00f", size = 1728239, upload-time = "2026-01-03T17:30:32.703Z" },
+    { url = "https://files.pythonhosted.org/packages/47/71/6f72f77f9f7d74719692ab65a2a0252584bf8d5f301e2ecb4c0da734530a/aiohttp-3.13.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:96d604498a7c782cb15a51c406acaea70d8c027ee6b90c569baa6e7b93073679", size = 1740527, upload-time = "2026-01-03T17:30:34.695Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/b4/75ec16cbbd5c01bdaf4a05b19e103e78d7ce1ef7c80867eb0ace42ff4488/aiohttp-3.13.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:084911a532763e9d3dd95adf78a78f4096cd5f58cdc18e6fdbc1b58417a45423", size = 1554489, upload-time = "2026-01-03T17:30:36.864Z" },
+    { url = "https://files.pythonhosted.org/packages/52/8f/bc518c0eea29f8406dcf7ed1f96c9b48e3bc3995a96159b3fc11f9e08321/aiohttp-3.13.3-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:7a4a94eb787e606d0a09404b9c38c113d3b099d508021faa615d70a0131907ce", size = 1767852, upload-time = "2026-01-03T17:30:39.433Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f2/a07a75173124f31f11ea6f863dc44e6f09afe2bca45dd4e64979490deab1/aiohttp-3.13.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:87797e645d9d8e222e04160ee32aa06bc5c163e8499f24db719e7852ec23093a", size = 1722379, upload-time = "2026-01-03T17:30:41.081Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/4a/1a3fee7c21350cac78e5c5cef711bac1b94feca07399f3d406972e2d8fcd/aiohttp-3.13.3-cp312-cp312-win32.whl", hash = "sha256:b04be762396457bef43f3597c991e192ee7da460a4953d7e647ee4b1c28e7046", size = 428253, upload-time = "2026-01-03T17:30:42.644Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b7/76175c7cb4eb73d91ad63c34e29fc4f77c9386bba4a65b53ba8e05ee3c39/aiohttp-3.13.3-cp312-cp312-win_amd64.whl", hash = "sha256:e3531d63d3bdfa7e3ac5e9b27b2dd7ec9df3206a98e0b3445fa906f233264c57", size = 455407, upload-time = "2026-01-03T17:30:44.195Z" },
+]
+
+[[package]]
+name = "aiosignal"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "frozenlist" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
+]
+
+[[package]]
+name = "async-timeout"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "25.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11", size = 934251, upload-time = "2025-10-06T13:54:44.725Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373", size = 67615, upload-time = "2025-10-06T13:54:43.17Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.2.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/35/02daf95b9cd686320bb622eb148792655c9412dbb9b67abb5694e5910a24/charset_normalizer-3.4.5.tar.gz", hash = "sha256:95adae7b6c42a6c5b5b559b1a99149f090a57128155daeea91732c8d970d8644", size = 134804, upload-time = "2026-03-06T06:03:19.46Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/21/a2b1505639008ba2e6ef03733a81fc6cfd6a07ea6139a2b76421230b8dad/charset_normalizer-3.4.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:4167a621a9a1a986c73777dbc15d4b5eac8ac5c10393374109a343d4013ec765", size = 283319, upload-time = "2026-03-06T06:00:26.433Z" },
+    { url = "https://files.pythonhosted.org/packages/70/67/df234c29b68f4e1e095885c9db1cb4b69b8aba49cf94fac041db4aaf1267/charset_normalizer-3.4.5-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3f64c6bf8f32f9133b668c7f7a7cbdbc453412bc95ecdbd157f3b1e377a92990", size = 189974, upload-time = "2026-03-06T06:00:28.222Z" },
+    { url = "https://files.pythonhosted.org/packages/df/7f/fc66af802961c6be42e2c7b69c58f95cbd1f39b0e81b3365d8efe2a02a04/charset_normalizer-3.4.5-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:568e3c34b58422075a1b49575a6abc616d9751b4d61b23f712e12ebb78fe47b2", size = 207866, upload-time = "2026-03-06T06:00:29.769Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/23/404eb36fac4e95b833c50e305bba9a241086d427bb2167a42eac7c4f7da4/charset_normalizer-3.4.5-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:036c079aa08a6a592b82487f97c60b439428320ed1b2ea0b3912e99d30c77765", size = 203239, upload-time = "2026-03-06T06:00:31.086Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/2f/8a1d989bfadd120c90114ab33e0d2a0cbde05278c1fc15e83e62d570f50a/charset_normalizer-3.4.5-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:340810d34ef83af92148e96e3e44cb2d3f910d2bf95e5618a5c467d9f102231d", size = 196529, upload-time = "2026-03-06T06:00:32.608Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/0c/c75f85ff7ca1f051958bb518cd43922d86f576c03947a050fbedfdfb4f15/charset_normalizer-3.4.5-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:cd2d0f0ec9aa977a27731a3209ebbcacebebaf41f902bd453a928bfd281cf7f8", size = 184152, upload-time = "2026-03-06T06:00:33.93Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/20/4ed37f6199af5dde94d4aeaf577f3813a5ec6635834cda1d957013a09c76/charset_normalizer-3.4.5-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0b362bcd27819f9c07cbf23db4e0e8cd4b44c5ecd900c2ff907b2b92274a7412", size = 195226, upload-time = "2026-03-06T06:00:35.469Z" },
+    { url = "https://files.pythonhosted.org/packages/28/31/7ba1102178cba7c34dcc050f43d427172f389729e356038f0726253dd914/charset_normalizer-3.4.5-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:77be992288f720306ab4108fe5c74797de327f3248368dfc7e1a916d6ed9e5a2", size = 192933, upload-time = "2026-03-06T06:00:36.83Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/23/f86443ab3921e6a60b33b93f4a1161222231f6c69bc24fb18f3bee7b8518/charset_normalizer-3.4.5-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:8b78d8a609a4b82c273257ee9d631ded7fac0d875bdcdccc109f3ee8328cfcb1", size = 185647, upload-time = "2026-03-06T06:00:38.367Z" },
+    { url = "https://files.pythonhosted.org/packages/82/44/08b8be891760f1f5a6d23ce11d6d50c92981603e6eb740b4f72eea9424e2/charset_normalizer-3.4.5-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:ba20bdf69bd127f66d0174d6f2a93e69045e0b4036dc1ca78e091bcc765830c4", size = 209533, upload-time = "2026-03-06T06:00:41.931Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5f/df114f23406199f8af711ddccfbf409ffbc5b7cdc18fa19644997ff0c9bb/charset_normalizer-3.4.5-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:76a9d0de4d0eab387822e7b35d8f89367dd237c72e82ab42b9f7bf5e15ada00f", size = 195901, upload-time = "2026-03-06T06:00:43.978Z" },
+    { url = "https://files.pythonhosted.org/packages/07/83/71ef34a76fe8aa05ff8f840244bda2d61e043c2ef6f30d200450b9f6a1be/charset_normalizer-3.4.5-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:8fff79bf5978c693c9b1a4d71e4a94fddfb5fe744eb062a318e15f4a2f63a550", size = 204950, upload-time = "2026-03-06T06:00:45.202Z" },
+    { url = "https://files.pythonhosted.org/packages/58/40/0253be623995365137d7dc68e45245036207ab2227251e69a3d93ce43183/charset_normalizer-3.4.5-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c7e84e0c0005e3bdc1a9211cd4e62c78ba80bc37b2365ef4410cd2007a9047f2", size = 198546, upload-time = "2026-03-06T06:00:46.481Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/5c/5f3cb5b259a130895ef5ae16b38eaf141430fa3f7af50cd06c5d67e4f7b2/charset_normalizer-3.4.5-cp310-cp310-win32.whl", hash = "sha256:58ad8270cfa5d4bef1bc85bd387217e14ff154d6630e976c6f56f9a040757475", size = 132516, upload-time = "2026-03-06T06:00:47.924Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/c3/84fb174e7770f2df2e1a2115090771bfbc2227fb39a765c6d00568d1aab4/charset_normalizer-3.4.5-cp310-cp310-win_amd64.whl", hash = "sha256:02a9d1b01c1e12c27883b0c9349e0bcd9ae92e727ff1a277207e1a262b1cbf05", size = 142906, upload-time = "2026-03-06T06:00:49.389Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/b2/6f852f8b969f2cbd0d4092d2e60139ab1af95af9bb651337cae89ec0f684/charset_normalizer-3.4.5-cp310-cp310-win_arm64.whl", hash = "sha256:039215608ac7b358c4da0191d10fc76868567fbf276d54c14721bdedeb6de064", size = 133258, upload-time = "2026-03-06T06:00:51.051Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/9e/bcec3b22c64ecec47d39bf5167c2613efd41898c019dccd4183f6aa5d6a7/charset_normalizer-3.4.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:610f72c0ee565dfb8ae1241b666119582fdbfe7c0975c175be719f940e110694", size = 279531, upload-time = "2026-03-06T06:00:52.252Z" },
+    { url = "https://files.pythonhosted.org/packages/58/12/81fd25f7e7078ab5d1eedbb0fac44be4904ae3370a3bf4533c8f2d159acd/charset_normalizer-3.4.5-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:60d68e820af339df4ae8358c7a2e7596badeb61e544438e489035f9fbf3246a5", size = 188006, upload-time = "2026-03-06T06:00:53.8Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6e/f2d30e8c27c1b0736a6520311982cf5286cfc7f6cac77d7bc1325e3a23f2/charset_normalizer-3.4.5-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:10b473fc8dca1c3ad8559985794815f06ca3fc71942c969129070f2c3cdf7281", size = 205085, upload-time = "2026-03-06T06:00:55.311Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/90/d12cefcb53b5931e2cf792a33718d7126efb116a320eaa0742c7059a95e4/charset_normalizer-3.4.5-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d4eb8ac7469b2a5d64b5b8c04f84d8bf3ad340f4514b98523805cbf46e3b3923", size = 200545, upload-time = "2026-03-06T06:00:56.532Z" },
+    { url = "https://files.pythonhosted.org/packages/03/f4/44d3b830a20e89ff82a3134912d9a1cf6084d64f3b95dcad40f74449a654/charset_normalizer-3.4.5-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5bcb3227c3d9aaf73eaaab1db7ccd80a8995c509ee9941e2aae060ca6e4e5d81", size = 193863, upload-time = "2026-03-06T06:00:57.823Z" },
+    { url = "https://files.pythonhosted.org/packages/25/4b/f212119c18a6320a9d4a730d1b4057875cdeabf21b3614f76549042ef8a8/charset_normalizer-3.4.5-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:75ee9c1cce2911581a70a3c0919d8bccf5b1cbc9b0e5171400ec736b4b569497", size = 181827, upload-time = "2026-03-06T06:00:59.323Z" },
+    { url = "https://files.pythonhosted.org/packages/74/00/b26158e48b425a202a92965f8069e8a63d9af1481dfa206825d7f74d2a3c/charset_normalizer-3.4.5-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1d1401945cb77787dbd3af2446ff2d75912327c4c3a1526ab7955ecf8600687c", size = 191085, upload-time = "2026-03-06T06:01:00.546Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c2/1c1737bf6fd40335fe53d28fe49afd99ee4143cc57a845e99635ce0b9b6d/charset_normalizer-3.4.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0a45e504f5e1be0bd385935a8e1507c442349ca36f511a47057a71c9d1d6ea9e", size = 190688, upload-time = "2026-03-06T06:01:02.479Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/3d/abb5c22dc2ef493cd56522f811246a63c5427c08f3e3e50ab663de27fcf4/charset_normalizer-3.4.5-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:e09f671a54ce70b79a1fc1dc6da3072b7ef7251fadb894ed92d9aa8218465a5f", size = 183077, upload-time = "2026-03-06T06:01:04.231Z" },
+    { url = "https://files.pythonhosted.org/packages/44/33/5298ad4d419a58e25b3508e87f2758d1442ff00c2471f8e0403dab8edad5/charset_normalizer-3.4.5-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:d01de5e768328646e6a3fa9e562706f8f6641708c115c62588aef2b941a4f88e", size = 206706, upload-time = "2026-03-06T06:01:05.773Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/17/51e7895ac0f87c3b91d276a449ef09f5532a7529818f59646d7a55089432/charset_normalizer-3.4.5-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:131716d6786ad5e3dc542f5cc6f397ba3339dc0fb87f87ac30e550e8987756af", size = 191665, upload-time = "2026-03-06T06:01:07.473Z" },
+    { url = "https://files.pythonhosted.org/packages/90/8f/cce9adf1883e98906dbae380d769b4852bb0fa0004bc7d7a2243418d3ea8/charset_normalizer-3.4.5-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:1a374cc0b88aa710e8865dc1bd6edb3743c59f27830f0293ab101e4cf3ce9f85", size = 201950, upload-time = "2026-03-06T06:01:08.973Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ca/bce99cd5c397a52919e2769d126723f27a4c037130374c051c00470bcd38/charset_normalizer-3.4.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d31f0d1671e1534e395f9eb84a68e0fb670e1edb1fe819a9d7f564ae3bc4e53f", size = 195830, upload-time = "2026-03-06T06:01:10.155Z" },
+    { url = "https://files.pythonhosted.org/packages/87/4f/2e3d023a06911f1281f97b8f036edc9872167036ca6f55cc874a0be6c12c/charset_normalizer-3.4.5-cp311-cp311-win32.whl", hash = "sha256:cace89841c0599d736d3d74a27bc5821288bb47c5441923277afc6059d7fbcb4", size = 132029, upload-time = "2026-03-06T06:01:11.706Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/1f/a853b73d386521fd44b7f67ded6b17b7b2367067d9106a5c4b44f9a34274/charset_normalizer-3.4.5-cp311-cp311-win_amd64.whl", hash = "sha256:f8102ae93c0bc863b1d41ea0f4499c20a83229f52ed870850892df555187154a", size = 142404, upload-time = "2026-03-06T06:01:12.865Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/10/dba36f76b71c38e9d391abe0fd8a5b818790e053c431adecfc98c35cd2a9/charset_normalizer-3.4.5-cp311-cp311-win_arm64.whl", hash = "sha256:ed98364e1c262cf5f9363c3eca8c2df37024f52a8fa1180a3610014f26eac51c", size = 132796, upload-time = "2026-03-06T06:01:14.106Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/b6/9ee9c1a608916ca5feae81a344dffbaa53b26b90be58cc2159e3332d44ec/charset_normalizer-3.4.5-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ed97c282ee4f994ef814042423a529df9497e3c666dca19be1d4cd1129dc7ade", size = 280976, upload-time = "2026-03-06T06:01:15.276Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d8/a54f7c0b96f1df3563e9190f04daf981e365a9b397eedfdfb5dbef7e5c6c/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0294916d6ccf2d069727d65973c3a1ca477d68708db25fd758dd28b0827cff54", size = 189356, upload-time = "2026-03-06T06:01:16.511Z" },
+    { url = "https://files.pythonhosted.org/packages/42/69/2bf7f76ce1446759a5787cb87d38f6a61eb47dbbdf035cfebf6347292a65/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:dc57a0baa3eeedd99fafaef7511b5a6ef4581494e8168ee086031744e2679467", size = 206369, upload-time = "2026-03-06T06:01:17.853Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9c/949d1a46dab56b959d9a87272482195f1840b515a3380e39986989a893ae/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ed1a9a204f317ef879b32f9af507d47e49cd5e7f8e8d5d96358c98373314fc60", size = 203285, upload-time = "2026-03-06T06:01:19.473Z" },
+    { url = "https://files.pythonhosted.org/packages/67/5c/ae30362a88b4da237d71ea214a8c7eb915db3eec941adda511729ac25fa2/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7ad83b8f9379176c841f8865884f3514d905bcd2a9a3b210eaa446e7d2223e4d", size = 196274, upload-time = "2026-03-06T06:01:20.728Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/07/c9f2cb0e46cb6d64fdcc4f95953747b843bb2181bda678dc4e699b8f0f9a/charset_normalizer-3.4.5-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:a118e2e0b5ae6b0120d5efa5f866e58f2bb826067a646431da4d6a2bdae7950e", size = 184715, upload-time = "2026-03-06T06:01:22.194Z" },
+    { url = "https://files.pythonhosted.org/packages/36/64/6b0ca95c44fddf692cd06d642b28f63009d0ce325fad6e9b2b4d0ef86a52/charset_normalizer-3.4.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:754f96058e61a5e22e91483f823e07df16416ce76afa4ebf306f8e1d1296d43f", size = 193426, upload-time = "2026-03-06T06:01:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/50/bc/a730690d726403743795ca3f5bb2baf67838c5fea78236098f324b965e40/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0c300cefd9b0970381a46394902cd18eaf2aa00163f999590ace991989dcd0fc", size = 191780, upload-time = "2026-03-06T06:01:25.053Z" },
+    { url = "https://files.pythonhosted.org/packages/97/4f/6c0bc9af68222b22951552d73df4532b5be6447cee32d58e7e8c74ecbb7b/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:c108f8619e504140569ee7de3f97d234f0fbae338a7f9f360455071ef9855a95", size = 185805, upload-time = "2026-03-06T06:01:26.294Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/b9/a523fb9b0ee90814b503452b2600e4cbc118cd68714d57041564886e7325/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:d1028de43596a315e2720a9849ee79007ab742c06ad8b45a50db8cdb7ed4a82a", size = 208342, upload-time = "2026-03-06T06:01:27.55Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/61/c59e761dee4464050713e50e27b58266cc8e209e518c0b378c1580c959ba/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:19092dde50335accf365cce21998a1c6dd8eafd42c7b226eb54b2747cdce2fac", size = 193661, upload-time = "2026-03-06T06:01:29.051Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/43/729fa30aad69783f755c5ad8649da17ee095311ca42024742701e202dc59/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:4354e401eb6dab9aed3c7b4030514328a6c748d05e1c3e19175008ca7de84fb1", size = 204819, upload-time = "2026-03-06T06:01:30.298Z" },
+    { url = "https://files.pythonhosted.org/packages/87/33/d9b442ce5a91b96fc0840455a9e49a611bbadae6122778d0a6a79683dd31/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a68766a3c58fde7f9aaa22b3786276f62ab2f594efb02d0a1421b6282e852e98", size = 198080, upload-time = "2026-03-06T06:01:31.478Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5a/b8b5a23134978ee9885cee2d6995f4c27cc41f9baded0a9685eabc5338f0/charset_normalizer-3.4.5-cp312-cp312-win32.whl", hash = "sha256:1827734a5b308b65ac54e86a618de66f935a4f63a8a462ff1e19a6788d6c2262", size = 132630, upload-time = "2026-03-06T06:01:33.056Z" },
+    { url = "https://files.pythonhosted.org/packages/70/53/e44a4c07e8904500aec95865dc3f6464dc3586a039ef0df606eb3ac38e35/charset_normalizer-3.4.5-cp312-cp312-win_amd64.whl", hash = "sha256:728c6a963dfab66ef865f49286e45239384249672cd598576765acc2a640a636", size = 142856, upload-time = "2026-03-06T06:01:34.489Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/aa/c5628f7cad591b1cf45790b7a61483c3e36cf41349c98af7813c483fd6e8/charset_normalizer-3.4.5-cp312-cp312-win_arm64.whl", hash = "sha256:75dfd1afe0b1647449e852f4fb428195a7ed0588947218f7ba929f6538487f02", size = 132982, upload-time = "2026-03-06T06:01:35.641Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/60/3a621758945513adfd4db86827a5bafcc615f913dbd0b4c2ed64a65731be/charset_normalizer-3.4.5-py3-none-any.whl", hash = "sha256:9db5e3fcdcee89a78c04dffb3fe33c79f77bd741a624946db2591c81b2fc85b0", size = 55455, upload-time = "2026-03-06T06:03:17.827Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptg"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/e0/d1b637d638513191793971b985151b48ac656d5fcce79771f1e5541a7acf/cryptg-0.5.2.tar.gz", hash = "sha256:d1577e219d040695f34ae7c2636c9ed769fe623813009e27dbc735beed69bd16", size = 13347, upload-time = "2025-10-12T08:39:51.185Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/c6/7752a958e7fe98fab72f5c0859e95cb8d84c986f47558c23a20c64c74913/cryptg-0.5.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:bbabe74b321415d5dbea58a30ef96ba53a196de57dd48c876266e0304ddaeb5d", size = 213724, upload-time = "2025-10-12T08:56:53.325Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/38/e40268c87f2ed6eb38983508d5657cdce18d8a35b173986c7e98cf33b750/cryptg-0.5.2-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:928264608c721032d407541fb2e6119a6e5b5d87d8ee244de5a68263301fcad7", size = 243529, upload-time = "2025-10-12T08:56:54.897Z" },
+    { url = "https://files.pythonhosted.org/packages/61/18/780ecaeb290c34122d0c98f5a0089ad2163e323689d0c0ca88d1c1789599/cryptg-0.5.2-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:f05d56fe5aef63e3fcfc76714d41fb2b2378730551a455dd615d0fdd49fd9037", size = 255276, upload-time = "2025-10-12T08:56:55.965Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/4a/835d3e816a3187932bffc595c339ccea15c1063f7e8f27b65bbcaf2819d3/cryptg-0.5.2-cp310-cp310-win32.whl", hash = "sha256:c6806680964cad8723d110228fcf1cbdb40eebfbd19e91e4f55ebf48ce95a223", size = 112783, upload-time = "2025-10-12T08:56:57.281Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/20/eb3deb01237ba751b6c2c117c2ee4be0596ccd87d5dfbff4305b88df7783/cryptg-0.5.2-cp310-cp310-win_amd64.whl", hash = "sha256:195a9f5f1a834ad8ac9989dcf95563f37e0332d734c64b4150e99cdb71f0bb53", size = 113641, upload-time = "2025-10-12T08:56:58.435Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/88/050a378998d9f14b88955d5e3119b0d5822830e42376ff69023c12a4108e/cryptg-0.5.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:40e6002f3dd522711b33fd8ace2424f295dd557251d255c6f0ab1cd7a6f8c662", size = 213527, upload-time = "2025-10-12T08:56:59.6Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/82/c977ae8906bed76b068e25ba70fecb7f8f79ba43be13a290a55ee527ee19/cryptg-0.5.2-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:ef778055445d451b4467cda4252a23cb659666012b97c43cce25d08b55f8fb4a", size = 243025, upload-time = "2025-10-12T08:57:00.71Z" },
+    { url = "https://files.pythonhosted.org/packages/21/4e/fdd0ca11105c02dc7879f6df6e7b0f7ce7e85a262938d3f9657d450ba102/cryptg-0.5.2-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:682b19897ebef8a910fdfe5fc379689334fdc197cb17bb13763f27153c856cb2", size = 255120, upload-time = "2025-10-12T08:57:02.016Z" },
+    { url = "https://files.pythonhosted.org/packages/02/04/f4834326b0aaff222a35f4b138fed51d5619627c2bd02c94a08f7ab6df21/cryptg-0.5.2-cp311-cp311-win32.whl", hash = "sha256:e83a0c9f141af8fe426c9967cec802ab01e207edb6aeb3fb8f0d94f9fbb76b92", size = 112529, upload-time = "2025-10-12T08:57:03.349Z" },
+    { url = "https://files.pythonhosted.org/packages/22/de/edf6d5bcee436b5e3c764f25486c646fe47f5e18cdc0fad37bc6b4d96ab5/cryptg-0.5.2-cp311-cp311-win_amd64.whl", hash = "sha256:b677d8e3be717c740a05eaf042e92e6f3e0f07dd3383bc4b1878b71cf4048d84", size = 113574, upload-time = "2025-10-12T08:57:04.773Z" },
+    { url = "https://files.pythonhosted.org/packages/81/ea/4752cbd74369a27662960d9476918e549590ad91b68e911fffd106695dc7/cryptg-0.5.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:eb28fcde47e02421926dbb83dbb0793d21d783125b95bda68414e46c76b1c9e1", size = 211666, upload-time = "2025-10-12T08:57:05.671Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/ad/4873a1ecd602aed7618bcf2dce4099834c73423b4793bbe815b942ab67d2/cryptg-0.5.2-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:5f51de5fa87cca9c3b2c019eae0ba7f4a27fd0ac23a6b52970e14ab6e590c11f", size = 243573, upload-time = "2025-10-12T08:57:07.062Z" },
+    { url = "https://files.pythonhosted.org/packages/34/2e/50fda8d43646db4be92071979722600440f852e70eda67379a55b686a376/cryptg-0.5.2-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:207c6c717c5e2d544f11523ce8c56982e40fbfc4b3a6eebf70e3e7b37c2be14e", size = 255038, upload-time = "2025-10-12T08:57:08.336Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/bf/e7fcb0887a8ec340b2f28a54dd2105b271e7574ae99eb1222bb8cb85cebc/cryptg-0.5.2-cp312-cp312-win32.whl", hash = "sha256:3c0c1edd348bbbebc5a6fd553cdeb861d85016c73dd5dfc368a0bee343a6fb25", size = 113108, upload-time = "2025-10-12T08:57:09.387Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a7/54c2a6f3559708a04023f31407628d6db3e2482b059b226dc3f4c41ffbe1/cryptg-0.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:c9b6ae5d30c3c164ac44b6b212887ed7d56f55e2fb207c7f93332ef2624fd936", size = 113710, upload-time = "2025-10-12T08:57:10.284Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/3f/1e3881853448cd32c5f94987603cfaac270713d1d749eea1a78d6eece4c1/cryptg-0.5.2-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:fdbeea1fb061b5a7bc273f6c6ed40cd7b7a05600305d4a8f7002c29b2555c95c", size = 215198, upload-time = "2025-10-12T08:57:39.044Z" },
+    { url = "https://files.pythonhosted.org/packages/59/03/5d5d64a3f74595d8258b52ac934041a1dc24a046c9e9d7d8dff3b3938601/cryptg-0.5.2-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:08b15f841691fc71735aeace24107c0975c3a0e8806e65762492c961013d6e5d", size = 244530, upload-time = "2025-10-12T08:57:40.224Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/f06e91ebd2023271f8fa272ec0e80d32085640b071cc4107a70feb51344e/cryptg-0.5.2-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:ee0d1c5371c34f31ec1bf0fba3c86257b5f19cf8e1411138ebc771e21509bd6a", size = 255904, upload-time = "2025-10-12T08:57:41.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/41/133bbb63e58669f60349429782c67f309520a01f373326c87adc981a52c5/cryptg-0.5.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:11d3b512db21905d8b26bc1493ee45bbc73e3dd285cbb412539c05e256cd46aa", size = 114494, upload-time = "2025-10-12T08:57:42.266Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/64/0526cc46968630cd2e4f6637c83431a47296bb2c2d80cda0fcf779b365d5/cryptg-0.5.2-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:7da6a02027684c1c56d8e3a13a2341ec2fc67792036ed356dcc54bd08fdee485", size = 214875, upload-time = "2025-10-12T08:57:43.152Z" },
+    { url = "https://files.pythonhosted.org/packages/58/e9/62042808e99bbb09896c57e047a317851595ac0c45d79ceed8a98254ac72/cryptg-0.5.2-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:973e67117296bf0ad4dc21607fd699d9da3b95d66f6f39d981b522523e778f3f", size = 244198, upload-time = "2025-10-12T08:57:44.139Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/05/80feec5026430371208e0d53ca642b4706a59678590319890bbddb6dfe5a/cryptg-0.5.2-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:74a6416ebff5af10f0d837c2790a55086efe3ae5115c0da50948d0c95f144c03", size = 255576, upload-time = "2025-10-12T08:57:45.094Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/d9/35f820588f581e5fbd5392abd299c08effde9184ed4b766d67b06e67f780/cryptg-0.5.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:bd2ea1261454ac415e4127a5bf3f4795bd404c9f1041bf98cf02a7e23ff253b7", size = 114253, upload-time = "2025-10-12T08:57:46.376Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "frozenlist"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f5/c831fac6cc817d26fd54c7eaccd04ef7e0288806943f7cc5bbf69f3ac1f0/frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad", size = 45875, upload-time = "2025-10-06T05:38:17.865Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/4a/557715d5047da48d54e659203b9335be7bfaafda2c3f627b7c47e0b3aaf3/frozenlist-1.8.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b37f6d31b3dcea7deb5e9696e529a6aa4a898adc33db82da12e4c60a7c4d2011", size = 86230, upload-time = "2025-10-06T05:35:23.699Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/fb/c85f9fed3ea8fe8740e5b46a59cc141c23b842eca617da8876cfce5f760e/frozenlist-1.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ef2b7b394f208233e471abc541cc6991f907ffd47dc72584acee3147899d6565", size = 49621, upload-time = "2025-10-06T05:35:25.341Z" },
+    { url = "https://files.pythonhosted.org/packages/63/70/26ca3f06aace16f2352796b08704338d74b6d1a24ca38f2771afbb7ed915/frozenlist-1.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a88f062f072d1589b7b46e951698950e7da00442fc1cacbe17e19e025dc327ad", size = 49889, upload-time = "2025-10-06T05:35:26.797Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ed/c7895fd2fde7f3ee70d248175f9b6cdf792fb741ab92dc59cd9ef3bd241b/frozenlist-1.8.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f57fb59d9f385710aa7060e89410aeb5058b99e62f4d16b08b91986b9a2140c2", size = 219464, upload-time = "2025-10-06T05:35:28.254Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/83/4d587dccbfca74cb8b810472392ad62bfa100bf8108c7223eb4c4fa2f7b3/frozenlist-1.8.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:799345ab092bee59f01a915620b5d014698547afd011e691a208637312db9186", size = 221649, upload-time = "2025-10-06T05:35:29.454Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c6/fd3b9cd046ec5fff9dab66831083bc2077006a874a2d3d9247dea93ddf7e/frozenlist-1.8.0-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c23c3ff005322a6e16f71bf8692fcf4d5a304aaafe1e262c98c6d4adc7be863e", size = 219188, upload-time = "2025-10-06T05:35:30.951Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/80/6693f55eb2e085fc8afb28cf611448fb5b90e98e068fa1d1b8d8e66e5c7d/frozenlist-1.8.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8a76ea0f0b9dfa06f254ee06053d93a600865b3274358ca48a352ce4f0798450", size = 231748, upload-time = "2025-10-06T05:35:32.101Z" },
+    { url = "https://files.pythonhosted.org/packages/97/d6/e9459f7c5183854abd989ba384fe0cc1a0fb795a83c033f0571ec5933ca4/frozenlist-1.8.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c7366fe1418a6133d5aa824ee53d406550110984de7637d65a178010f759c6ef", size = 236351, upload-time = "2025-10-06T05:35:33.834Z" },
+    { url = "https://files.pythonhosted.org/packages/97/92/24e97474b65c0262e9ecd076e826bfd1d3074adcc165a256e42e7b8a7249/frozenlist-1.8.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:13d23a45c4cebade99340c4165bd90eeb4a56c6d8a9d8aa49568cac19a6d0dc4", size = 218767, upload-time = "2025-10-06T05:35:35.205Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/bf/dc394a097508f15abff383c5108cb8ad880d1f64a725ed3b90d5c2fbf0bb/frozenlist-1.8.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:e4a3408834f65da56c83528fb52ce7911484f0d1eaf7b761fc66001db1646eff", size = 235887, upload-time = "2025-10-06T05:35:36.354Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/25b201b9c015dbc999a5baf475a257010471a1fa8c200c843fd4abbee725/frozenlist-1.8.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:42145cd2748ca39f32801dad54aeea10039da6f86e303659db90db1c4b614c8c", size = 228785, upload-time = "2025-10-06T05:35:37.949Z" },
+    { url = "https://files.pythonhosted.org/packages/84/f4/b5bc148df03082f05d2dd30c089e269acdbe251ac9a9cf4e727b2dbb8a3d/frozenlist-1.8.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:e2de870d16a7a53901e41b64ffdf26f2fbb8917b3e6ebf398098d72c5b20bd7f", size = 230312, upload-time = "2025-10-06T05:35:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4b/87e95b5d15097c302430e647136b7d7ab2398a702390cf4c8601975709e7/frozenlist-1.8.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:20e63c9493d33ee48536600d1a5c95eefc870cd71e7ab037763d1fbb89cc51e7", size = 217650, upload-time = "2025-10-06T05:35:40.377Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/70/78a0315d1fea97120591a83e0acd644da638c872f142fd72a6cebee825f3/frozenlist-1.8.0-cp310-cp310-win32.whl", hash = "sha256:adbeebaebae3526afc3c96fad434367cafbfd1b25d72369a9e5858453b1bb71a", size = 39659, upload-time = "2025-10-06T05:35:41.863Z" },
+    { url = "https://files.pythonhosted.org/packages/66/aa/3f04523fb189a00e147e60c5b2205126118f216b0aa908035c45336e27e4/frozenlist-1.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:667c3777ca571e5dbeb76f331562ff98b957431df140b54c85fd4d52eea8d8f6", size = 43837, upload-time = "2025-10-06T05:35:43.205Z" },
+    { url = "https://files.pythonhosted.org/packages/39/75/1135feecdd7c336938bd55b4dc3b0dfc46d85b9be12ef2628574b28de776/frozenlist-1.8.0-cp310-cp310-win_arm64.whl", hash = "sha256:80f85f0a7cc86e7a54c46d99c9e1318ff01f4687c172ede30fd52d19d1da1c8e", size = 39989, upload-time = "2025-10-06T05:35:44.596Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/03/077f869d540370db12165c0aa51640a873fb661d8b315d1d4d67b284d7ac/frozenlist-1.8.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:09474e9831bc2b2199fad6da3c14c7b0fbdd377cce9d3d77131be28906cb7d84", size = 86912, upload-time = "2025-10-06T05:35:45.98Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b5/7610b6bd13e4ae77b96ba85abea1c8cb249683217ef09ac9e0ae93f25a91/frozenlist-1.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:17c883ab0ab67200b5f964d2b9ed6b00971917d5d8a92df149dc2c9779208ee9", size = 50046, upload-time = "2025-10-06T05:35:47.009Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ef/0e8f1fe32f8a53dd26bdd1f9347efe0778b0fddf62789ea683f4cc7d787d/frozenlist-1.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:fa47e444b8ba08fffd1c18e8cdb9a75db1b6a27f17507522834ad13ed5922b93", size = 50119, upload-time = "2025-10-06T05:35:48.38Z" },
+    { url = "https://files.pythonhosted.org/packages/11/b1/71a477adc7c36e5fb628245dfbdea2166feae310757dea848d02bd0689fd/frozenlist-1.8.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2552f44204b744fba866e573be4c1f9048d6a324dfe14475103fd51613eb1d1f", size = 231067, upload-time = "2025-10-06T05:35:49.97Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7e/afe40eca3a2dc19b9904c0f5d7edfe82b5304cb831391edec0ac04af94c2/frozenlist-1.8.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:957e7c38f250991e48a9a73e6423db1bb9dd14e722a10f6b8bb8e16a0f55f695", size = 233160, upload-time = "2025-10-06T05:35:51.729Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/aa/7416eac95603ce428679d273255ffc7c998d4132cfae200103f164b108aa/frozenlist-1.8.0-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:8585e3bb2cdea02fc88ffa245069c36555557ad3609e83be0ec71f54fd4abb52", size = 228544, upload-time = "2025-10-06T05:35:53.246Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/3d/2a2d1f683d55ac7e3875e4263d28410063e738384d3adc294f5ff3d7105e/frozenlist-1.8.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:edee74874ce20a373d62dc28b0b18b93f645633c2943fd90ee9d898550770581", size = 243797, upload-time = "2025-10-06T05:35:54.497Z" },
+    { url = "https://files.pythonhosted.org/packages/78/1e/2d5565b589e580c296d3bb54da08d206e797d941a83a6fdea42af23be79c/frozenlist-1.8.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c9a63152fe95756b85f31186bddf42e4c02c6321207fd6601a1c89ebac4fe567", size = 247923, upload-time = "2025-10-06T05:35:55.861Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/c3/65872fcf1d326a7f101ad4d86285c403c87be7d832b7470b77f6d2ed5ddc/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b6db2185db9be0a04fecf2f241c70b63b1a242e2805be291855078f2b404dd6b", size = 230886, upload-time = "2025-10-06T05:35:57.399Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/76/ac9ced601d62f6956f03cc794f9e04c81719509f85255abf96e2510f4265/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:f4be2e3d8bc8aabd566f8d5b8ba7ecc09249d74ba3c9ed52e54dc23a293f0b92", size = 245731, upload-time = "2025-10-06T05:35:58.563Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/49/ecccb5f2598daf0b4a1415497eba4c33c1e8ce07495eb07d2860c731b8d5/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:c8d1634419f39ea6f5c427ea2f90ca85126b54b50837f31497f3bf38266e853d", size = 241544, upload-time = "2025-10-06T05:35:59.719Z" },
+    { url = "https://files.pythonhosted.org/packages/53/4b/ddf24113323c0bbcc54cb38c8b8916f1da7165e07b8e24a717b4a12cbf10/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:1a7fa382a4a223773ed64242dbe1c9c326ec09457e6b8428efb4118c685c3dfd", size = 241806, upload-time = "2025-10-06T05:36:00.959Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/fb/9b9a084d73c67175484ba2789a59f8eebebd0827d186a8102005ce41e1ba/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:11847b53d722050808926e785df837353bd4d75f1d494377e59b23594d834967", size = 229382, upload-time = "2025-10-06T05:36:02.22Z" },
+    { url = "https://files.pythonhosted.org/packages/95/a3/c8fb25aac55bf5e12dae5c5aa6a98f85d436c1dc658f21c3ac73f9fa95e5/frozenlist-1.8.0-cp311-cp311-win32.whl", hash = "sha256:27c6e8077956cf73eadd514be8fb04d77fc946a7fe9f7fe167648b0b9085cc25", size = 39647, upload-time = "2025-10-06T05:36:03.409Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/f5/603d0d6a02cfd4c8f2a095a54672b3cf967ad688a60fb9faf04fc4887f65/frozenlist-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:ac913f8403b36a2c8610bbfd25b8013488533e71e62b4b4adce9c86c8cea905b", size = 44064, upload-time = "2025-10-06T05:36:04.368Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/16/c2c9ab44e181f043a86f9a8f84d5124b62dbcb3a02c0977ec72b9ac1d3e0/frozenlist-1.8.0-cp311-cp311-win_arm64.whl", hash = "sha256:d4d3214a0f8394edfa3e303136d0575eece0745ff2b47bd2cb2e66dd92d4351a", size = 39937, upload-time = "2025-10-06T05:36:05.669Z" },
+    { url = "https://files.pythonhosted.org/packages/69/29/948b9aa87e75820a38650af445d2ef2b6b8a6fab1a23b6bb9e4ef0be2d59/frozenlist-1.8.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:78f7b9e5d6f2fdb88cdde9440dc147259b62b9d3b019924def9f6478be254ac1", size = 87782, upload-time = "2025-10-06T05:36:06.649Z" },
+    { url = "https://files.pythonhosted.org/packages/64/80/4f6e318ee2a7c0750ed724fa33a4bdf1eacdc5a39a7a24e818a773cd91af/frozenlist-1.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:229bf37d2e4acdaf808fd3f06e854a4a7a3661e871b10dc1f8f1896a3b05f18b", size = 50594, upload-time = "2025-10-06T05:36:07.69Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/94/5c8a2b50a496b11dd519f4a24cb5496cf125681dd99e94c604ccdea9419a/frozenlist-1.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f833670942247a14eafbb675458b4e61c82e002a148f49e68257b79296e865c4", size = 50448, upload-time = "2025-10-06T05:36:08.78Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/bd/d91c5e39f490a49df14320f4e8c80161cfcce09f1e2cde1edd16a551abb3/frozenlist-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:494a5952b1c597ba44e0e78113a7266e656b9794eec897b19ead706bd7074383", size = 242411, upload-time = "2025-10-06T05:36:09.801Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/83/f61505a05109ef3293dfb1ff594d13d64a2324ac3482be2cedc2be818256/frozenlist-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96f423a119f4777a4a056b66ce11527366a8bb92f54e541ade21f2374433f6d4", size = 243014, upload-time = "2025-10-06T05:36:11.394Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/cb/cb6c7b0f7d4023ddda30cf56b8b17494eb3a79e3fda666bf735f63118b35/frozenlist-1.8.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3462dd9475af2025c31cc61be6652dfa25cbfb56cbbf52f4ccfe029f38decaf8", size = 234909, upload-time = "2025-10-06T05:36:12.598Z" },
+    { url = "https://files.pythonhosted.org/packages/31/c5/cd7a1f3b8b34af009fb17d4123c5a778b44ae2804e3ad6b86204255f9ec5/frozenlist-1.8.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c4c800524c9cd9bac5166cd6f55285957fcfc907db323e193f2afcd4d9abd69b", size = 250049, upload-time = "2025-10-06T05:36:14.065Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/01/2f95d3b416c584a1e7f0e1d6d31998c4a795f7544069ee2e0962a4b60740/frozenlist-1.8.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d6a5df73acd3399d893dafc71663ad22534b5aa4f94e8a2fabfe856c3c1b6a52", size = 256485, upload-time = "2025-10-06T05:36:15.39Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/03/024bf7720b3abaebcff6d0793d73c154237b85bdf67b7ed55e5e9596dc9a/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:405e8fe955c2280ce66428b3ca55e12b3c4e9c336fb2103a4937e891c69a4a29", size = 237619, upload-time = "2025-10-06T05:36:16.558Z" },
+    { url = "https://files.pythonhosted.org/packages/69/fa/f8abdfe7d76b731f5d8bd217827cf6764d4f1d9763407e42717b4bed50a0/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:908bd3f6439f2fef9e85031b59fd4f1297af54415fb60e4254a95f75b3cab3f3", size = 250320, upload-time = "2025-10-06T05:36:17.821Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/3c/b051329f718b463b22613e269ad72138cc256c540f78a6de89452803a47d/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:294e487f9ec720bd8ffcebc99d575f7eff3568a08a253d1ee1a0378754b74143", size = 246820, upload-time = "2025-10-06T05:36:19.046Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/ae/58282e8f98e444b3f4dd42448ff36fa38bef29e40d40f330b22e7108f565/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:74c51543498289c0c43656701be6b077f4b265868fa7f8a8859c197006efb608", size = 250518, upload-time = "2025-10-06T05:36:20.763Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/96/007e5944694d66123183845a106547a15944fbbb7154788cbf7272789536/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:776f352e8329135506a1d6bf16ac3f87bc25b28e765949282dcc627af36123aa", size = 239096, upload-time = "2025-10-06T05:36:22.129Z" },
+    { url = "https://files.pythonhosted.org/packages/66/bb/852b9d6db2fa40be96f29c0d1205c306288f0684df8fd26ca1951d461a56/frozenlist-1.8.0-cp312-cp312-win32.whl", hash = "sha256:433403ae80709741ce34038da08511d4a77062aa924baf411ef73d1146e74faf", size = 39985, upload-time = "2025-10-06T05:36:23.661Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/af/38e51a553dd66eb064cdf193841f16f077585d4d28394c2fa6235cb41765/frozenlist-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:34187385b08f866104f0c0617404c8eb08165ab1272e884abc89c112e9c00746", size = 44591, upload-time = "2025-10-06T05:36:24.958Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/06/1dc65480ab147339fecc70797e9c2f69d9cea9cf38934ce08df070fdb9cb/frozenlist-1.8.0-cp312-cp312-win_arm64.whl", hash = "sha256:fe3c58d2f5db5fbd18c2987cba06d51b0529f52bc3a6cdc33d3f4eab725104bd", size = 40102, upload-time = "2025-10-06T05:36:26.333Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "multidict"
+version = "6.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/c2/c2d94cbe6ac1753f3fc980da97b3d930efe1da3af3c9f5125354436c073d/multidict-6.7.1.tar.gz", hash = "sha256:ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d", size = 102010, upload-time = "2026-01-26T02:46:45.979Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/0b/19348d4c98980c4851d2f943f8ebafdece2ae7ef737adcfa5994ce8e5f10/multidict-6.7.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:c93c3db7ea657dd4637d57e74ab73de31bccefe144d3d4ce370052035bc85fb5", size = 77176, upload-time = "2026-01-26T02:42:59.784Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/04/9de3f8077852e3d438215c81e9b691244532d2e05b4270e89ce67b7d103c/multidict-6.7.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:974e72a2474600827abaeda71af0c53d9ebbc3c2eb7da37b37d7829ae31232d8", size = 44996, upload-time = "2026-01-26T02:43:01.674Z" },
+    { url = "https://files.pythonhosted.org/packages/31/5c/08c7f7fe311f32e83f7621cd3f99d805f45519cd06fafb247628b861da7d/multidict-6.7.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cdea2e7b2456cfb6694fb113066fd0ec7ea4d67e3a35e1f4cbeea0b448bf5872", size = 44631, upload-time = "2026-01-26T02:43:03.169Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/7f/0e3b1390ae772f27501199996b94b52ceeb64fe6f9120a32c6c3f6b781be/multidict-6.7.1-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:17207077e29342fdc2c9a82e4b306f1127bf1ea91f8b71e02d4798a70bb99991", size = 242561, upload-time = "2026-01-26T02:43:04.733Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/f4/8719f4f167586af317b69dd3e90f913416c91ca610cac79a45c53f590312/multidict-6.7.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4f49cb5661344764e4c7c7973e92a47a59b8fc19b6523649ec9dc4960e58a03", size = 242223, upload-time = "2026-01-26T02:43:06.695Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ab/7c36164cce64a6ad19c6d9a85377b7178ecf3b89f8fd589c73381a5eedfd/multidict-6.7.1-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a9fc4caa29e2e6ae408d1c450ac8bf19892c5fca83ee634ecd88a53332c59981", size = 222322, upload-time = "2026-01-26T02:43:08.472Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/79/a25add6fb38035b5337bc5734f296d9afc99163403bbcf56d4170f97eb62/multidict-6.7.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c5f0c21549ab432b57dcc82130f388d84ad8179824cc3f223d5e7cfbfd4143f6", size = 254005, upload-time = "2026-01-26T02:43:10.127Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/7b/64a87cf98e12f756fc8bd444b001232ffff2be37288f018ad0d3f0aae931/multidict-6.7.1-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7dfb78d966b2c906ae1d28ccf6e6712a3cd04407ee5088cd276fe8cb42186190", size = 251173, upload-time = "2026-01-26T02:43:11.731Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/ac/b605473de2bb404e742f2cc3583d12aedb2352a70e49ae8fce455b50c5aa/multidict-6.7.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9b0d9b91d1aa44db9c1f1ecd0d9d2ae610b2f4f856448664e01a3b35899f3f92", size = 243273, upload-time = "2026-01-26T02:43:13.063Z" },
+    { url = "https://files.pythonhosted.org/packages/03/65/11492d6a0e259783720f3bc1d9ea55579a76f1407e31ed44045c99542004/multidict-6.7.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:dd96c01a9dcd4889dcfcf9eb5544ca0c77603f239e3ffab0524ec17aea9a93ee", size = 238956, upload-time = "2026-01-26T02:43:14.843Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/a7/7ee591302af64e7c196fb63fe856c788993c1372df765102bd0448e7e165/multidict-6.7.1-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:067343c68cd6612d375710f895337b3a98a033c94f14b9a99eff902f205424e2", size = 233477, upload-time = "2026-01-26T02:43:16.025Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/99/c109962d58756c35fd9992fed7f2355303846ea2ff054bb5f5e9d6b888de/multidict-6.7.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:5884a04f4ff56c6120f6ccf703bdeb8b5079d808ba604d4d53aec0d55dc33568", size = 243615, upload-time = "2026-01-26T02:43:17.84Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/5f/1973e7c771c86e93dcfe1c9cc55a5481b610f6614acfc28c0d326fe6bfad/multidict-6.7.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:8affcf1c98b82bc901702eb73b6947a1bfa170823c153fe8a47b5f5f02e48e40", size = 249930, upload-time = "2026-01-26T02:43:19.06Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/a5/f170fc2268c3243853580203378cd522446b2df632061e0a5409817854c7/multidict-6.7.1-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:0d17522c37d03e85c8098ec8431636309b2682cf12e58f4dbc76121fb50e4962", size = 243807, upload-time = "2026-01-26T02:43:20.286Z" },
+    { url = "https://files.pythonhosted.org/packages/de/01/73856fab6d125e5bc652c3986b90e8699a95e84b48d72f39ade6c0e74a8c/multidict-6.7.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:24c0cf81544ca5e17cfcb6e482e7a82cd475925242b308b890c9452a074d4505", size = 239103, upload-time = "2026-01-26T02:43:21.508Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/46/f1220bd9944d8aa40d8ccff100eeeee19b505b857b6f603d6078cb5315b0/multidict-6.7.1-cp310-cp310-win32.whl", hash = "sha256:d82dd730a95e6643802f4454b8fdecdf08667881a9c5670db85bc5a56693f122", size = 41416, upload-time = "2026-01-26T02:43:22.703Z" },
+    { url = "https://files.pythonhosted.org/packages/68/00/9b38e272a770303692fc406c36e1a4c740f401522d5787691eb38a8925a8/multidict-6.7.1-cp310-cp310-win_amd64.whl", hash = "sha256:cf37cbe5ced48d417ba045aca1b21bafca67489452debcde94778a576666a1df", size = 46022, upload-time = "2026-01-26T02:43:23.77Z" },
+    { url = "https://files.pythonhosted.org/packages/64/65/d8d42490c02ee07b6bbe00f7190d70bb4738b3cce7629aaf9f213ef730dd/multidict-6.7.1-cp310-cp310-win_arm64.whl", hash = "sha256:59bc83d3f66b41dac1e7460aac1d196edc70c9ba3094965c467715a70ecb46db", size = 43238, upload-time = "2026-01-26T02:43:24.882Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/f1/a90635c4f88fb913fbf4ce660b83b7445b7a02615bda034b2f8eb38fd597/multidict-6.7.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7ff981b266af91d7b4b3793ca3382e53229088d193a85dfad6f5f4c27fc73e5d", size = 76626, upload-time = "2026-01-26T02:43:26.485Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/9b/267e64eaf6fc637a15b35f5de31a566634a2740f97d8d094a69d34f524a4/multidict-6.7.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:844c5bca0b5444adb44a623fb0a1310c2f4cd41f402126bb269cd44c9b3f3e1e", size = 44706, upload-time = "2026-01-26T02:43:27.607Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a4/d45caf2b97b035c57267791ecfaafbd59c68212004b3842830954bb4b02e/multidict-6.7.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f2a0a924d4c2e9afcd7ec64f9de35fcd96915149b2216e1cb2c10a56df483855", size = 44356, upload-time = "2026-01-26T02:43:28.661Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/d2/0a36c8473f0cbaeadd5db6c8b72d15bbceeec275807772bfcd059bef487d/multidict-6.7.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:8be1802715a8e892c784c0197c2ace276ea52702a0ede98b6310c8f255a5afb3", size = 244355, upload-time = "2026-01-26T02:43:31.165Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/16/8c65be997fd7dd311b7d39c7b6e71a0cb449bad093761481eccbbe4b42a2/multidict-6.7.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e2d2ed645ea29f31c4c7ea1552fcfd7cb7ba656e1eafd4134a6620c9f5fdd9e", size = 246433, upload-time = "2026-01-26T02:43:32.581Z" },
+    { url = "https://files.pythonhosted.org/packages/01/fb/4dbd7e848d2799c6a026ec88ad39cf2b8416aa167fcc903baa55ecaa045c/multidict-6.7.1-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:95922cee9a778659e91db6497596435777bd25ed116701a4c034f8e46544955a", size = 225376, upload-time = "2026-01-26T02:43:34.417Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/8a/4a3a6341eac3830f6053062f8fbc9a9e54407c80755b3f05bc427295c2d0/multidict-6.7.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6b83cabdc375ffaaa15edd97eb7c0c672ad788e2687004990074d7d6c9b140c8", size = 257365, upload-time = "2026-01-26T02:43:35.741Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a2/dd575a69c1aa206e12d27d0770cdf9b92434b48a9ef0cd0d1afdecaa93c4/multidict-6.7.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:38fb49540705369bab8484db0689d86c0a33a0a9f2c1b197f506b71b4b6c19b0", size = 254747, upload-time = "2026-01-26T02:43:36.976Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/56/21b27c560c13822ed93133f08aa6372c53a8e067f11fbed37b4adcdac922/multidict-6.7.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:439cbebd499f92e9aa6793016a8acaa161dfa749ae86d20960189f5398a19144", size = 246293, upload-time = "2026-01-26T02:43:38.258Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a4/23466059dc3854763423d0ad6c0f3683a379d97673b1b89ec33826e46728/multidict-6.7.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6d3bc717b6fe763b8be3f2bee2701d3c8eb1b2a8ae9f60910f1b2860c82b6c49", size = 242962, upload-time = "2026-01-26T02:43:40.034Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/67/51dd754a3524d685958001e8fa20a0f5f90a6a856e0a9dcabff69be3dbb7/multidict-6.7.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:619e5a1ac57986dbfec9f0b301d865dddf763696435e2962f6d9cf2fdff2bb71", size = 237360, upload-time = "2026-01-26T02:43:41.752Z" },
+    { url = "https://files.pythonhosted.org/packages/64/3f/036dfc8c174934d4b55d86ff4f978e558b0e585cef70cfc1ad01adc6bf18/multidict-6.7.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:0b38ebffd9be37c1170d33bc0f36f4f262e0a09bc1aac1c34c7aa51a7293f0b3", size = 245940, upload-time = "2026-01-26T02:43:43.042Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/20/6214d3c105928ebc353a1c644a6ef1408bc5794fcb4f170bb524a3c16311/multidict-6.7.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:10ae39c9cfe6adedcdb764f5e8411d4a92b055e35573a2eaa88d3323289ef93c", size = 253502, upload-time = "2026-01-26T02:43:44.371Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e2/c653bc4ae1be70a0f836b82172d643fcf1dade042ba2676ab08ec08bff0f/multidict-6.7.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:25167cc263257660290fba06b9318d2026e3c910be240a146e1f66dd114af2b0", size = 247065, upload-time = "2026-01-26T02:43:45.745Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/11/a854b4154cd3bd8b1fd375e8a8ca9d73be37610c361543d56f764109509b/multidict-6.7.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:128441d052254f42989ef98b7b6a6ecb1e6f708aa962c7984235316db59f50fa", size = 241870, upload-time = "2026-01-26T02:43:47.054Z" },
+    { url = "https://files.pythonhosted.org/packages/13/bf/9676c0392309b5fdae322333d22a829715b570edb9baa8016a517b55b558/multidict-6.7.1-cp311-cp311-win32.whl", hash = "sha256:d62b7f64ffde3b99d06b707a280db04fb3855b55f5a06df387236051d0668f4a", size = 41302, upload-time = "2026-01-26T02:43:48.753Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/68/f16a3a8ba6f7b6dc92a1f19669c0810bd2c43fc5a02da13b1cbf8e253845/multidict-6.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:bdbf9f3b332abd0cdb306e7c2113818ab1e922dc84b8f8fd06ec89ed2a19ab8b", size = 45981, upload-time = "2026-01-26T02:43:49.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ad/9dd5305253fa00cd3c7555dbef69d5bf4133debc53b87ab8d6a44d411665/multidict-6.7.1-cp311-cp311-win_arm64.whl", hash = "sha256:b8c990b037d2fff2f4e33d3f21b9b531c5745b33a49a7d6dbe7a177266af44f6", size = 43159, upload-time = "2026-01-26T02:43:51.635Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/9c/f20e0e2cf80e4b2e4b1c365bf5fe104ee633c751a724246262db8f1a0b13/multidict-6.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a90f75c956e32891a4eda3639ce6dd86e87105271f43d43442a3aedf3cddf172", size = 76893, upload-time = "2026-01-26T02:43:52.754Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/cf/18ef143a81610136d3da8193da9d80bfe1cb548a1e2d1c775f26b23d024a/multidict-6.7.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3fccb473e87eaa1382689053e4a4618e7ba7b9b9b8d6adf2027ee474597128cd", size = 45456, upload-time = "2026-01-26T02:43:53.893Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/65/1caac9d4cd32e8433908683446eebc953e82d22b03d10d41a5f0fefe991b/multidict-6.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b0fa96985700739c4c7853a43c0b3e169360d6855780021bfc6d0f1ce7c123e7", size = 43872, upload-time = "2026-01-26T02:43:55.041Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/3b/d6bd75dc4f3ff7c73766e04e705b00ed6dbbaccf670d9e05a12b006f5a21/multidict-6.7.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:cb2a55f408c3043e42b40cc8eecd575afa27b7e0b956dfb190de0f8499a57a53", size = 251018, upload-time = "2026-01-26T02:43:56.198Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/80/c959c5933adedb9ac15152e4067c702a808ea183a8b64cf8f31af8ad3155/multidict-6.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eb0ce7b2a32d09892b3dd6cc44877a0d02a33241fafca5f25c8b6b62374f8b75", size = 258883, upload-time = "2026-01-26T02:43:57.499Z" },
+    { url = "https://files.pythonhosted.org/packages/86/85/7ed40adafea3d4f1c8b916e3b5cc3a8e07dfcdcb9cd72800f4ed3ca1b387/multidict-6.7.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c3a32d23520ee37bf327d1e1a656fec76a2edd5c038bf43eddfa0572ec49c60b", size = 242413, upload-time = "2026-01-26T02:43:58.755Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/57/b8565ff533e48595503c785f8361ff9a4fde4d67de25c207cd0ba3befd03/multidict-6.7.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9c90fed18bffc0189ba814749fdcc102b536e83a9f738a9003e569acd540a733", size = 268404, upload-time = "2026-01-26T02:44:00.216Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/50/9810c5c29350f7258180dfdcb2e52783a0632862eb334c4896ac717cebcb/multidict-6.7.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:da62917e6076f512daccfbbde27f46fed1c98fee202f0559adec8ee0de67f71a", size = 269456, upload-time = "2026-01-26T02:44:02.202Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/8d/5e5be3ced1d12966fefb5c4ea3b2a5b480afcea36406559442c6e31d4a48/multidict-6.7.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bfde23ef6ed9db7eaee6c37dcec08524cb43903c60b285b172b6c094711b3961", size = 256322, upload-time = "2026-01-26T02:44:03.56Z" },
+    { url = "https://files.pythonhosted.org/packages/31/6e/d8a26d81ac166a5592782d208dd90dfdc0a7a218adaa52b45a672b46c122/multidict-6.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3758692429e4e32f1ba0df23219cd0b4fc0a52f476726fff9337d1a57676a582", size = 253955, upload-time = "2026-01-26T02:44:04.845Z" },
+    { url = "https://files.pythonhosted.org/packages/59/4c/7c672c8aad41534ba619bcd4ade7a0dc87ed6b8b5c06149b85d3dd03f0cd/multidict-6.7.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:398c1478926eca669f2fd6a5856b6de9c0acf23a2cb59a14c0ba5844fa38077e", size = 251254, upload-time = "2026-01-26T02:44:06.133Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/bd/84c24de512cbafbdbc39439f74e967f19570ce7924e3007174a29c348916/multidict-6.7.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:c102791b1c4f3ab36ce4101154549105a53dc828f016356b3e3bcae2e3a039d3", size = 252059, upload-time = "2026-01-26T02:44:07.518Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ba/f5449385510825b73d01c2d4087bf6d2fccc20a2d42ac34df93191d3dd03/multidict-6.7.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:a088b62bd733e2ad12c50dad01b7d0166c30287c166e137433d3b410add807a6", size = 263588, upload-time = "2026-01-26T02:44:09.382Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/11/afc7c677f68f75c84a69fe37184f0f82fce13ce4b92f49f3db280b7e92b3/multidict-6.7.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:3d51ff4785d58d3f6c91bdbffcb5e1f7ddfda557727043aa20d20ec4f65e324a", size = 259642, upload-time = "2026-01-26T02:44:10.73Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/17/ebb9644da78c4ab36403739e0e6e0e30ebb135b9caf3440825001a0bddcb/multidict-6.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc5907494fccf3e7d3f94f95c91d6336b092b5fc83811720fae5e2765890dfba", size = 251377, upload-time = "2026-01-26T02:44:12.042Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/a4/840f5b97339e27846c46307f2530a2805d9d537d8b8bd416af031cad7fa0/multidict-6.7.1-cp312-cp312-win32.whl", hash = "sha256:28ca5ce2fd9716631133d0e9a9b9a745ad7f60bac2bccafb56aa380fc0b6c511", size = 41887, upload-time = "2026-01-26T02:44:14.245Z" },
+    { url = "https://files.pythonhosted.org/packages/80/31/0b2517913687895f5904325c2069d6a3b78f66cc641a86a2baf75a05dcbb/multidict-6.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcee94dfbd638784645b066074b338bc9cc155d4b4bffa4adce1615c5a426c19", size = 46053, upload-time = "2026-01-26T02:44:15.371Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/5b/aba28e4ee4006ae4c7df8d327d31025d760ffa992ea23812a601d226e682/multidict-6.7.1-cp312-cp312-win_arm64.whl", hash = "sha256:ba0a9fb644d0c1a2194cf7ffb043bd852cea63a57f66fbd33959f7dae18517bf", size = 43307, upload-time = "2026-01-26T02:44:16.852Z" },
+    { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
+]
+
+[[package]]
+name = "openai"
+version = "0.27.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "requests" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/ee/84bbd0161090f0f24e8a2ac175e6b6a936289ee02e9d5da414ce14d3d332/openai-0.27.8.tar.gz", hash = "sha256:2483095c7db1eee274cebac79e315a986c4e55207bb4fa7b82d185b3a2ed9536", size = 60012, upload-time = "2023-06-07T00:15:58.811Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/78/7588a047e458cb8075a4089d721d7af5e143ff85a2388d4a28c530be0494/openai-0.27.8-py3-none-any.whl", hash = "sha256:e0a7c2f7da26bdbe5354b03c6d4b82a2f34bd4458c7a17ae1a7092c3e397e03c", size = 73553, upload-time = "2023-06-07T00:15:56.862Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "propcache"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/da/e9fc233cf63743258bff22b3dfa7ea5baef7b5bc324af47a0ad89b8ffc6f/propcache-0.4.1.tar.gz", hash = "sha256:f48107a8c637e80362555f37ecf49abe20370e557cc4ab374f04ec4423c97c3d", size = 46442, upload-time = "2025-10-08T19:49:02.291Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/0e/934b541323035566a9af292dba85a195f7b78179114f2c6ebb24551118a9/propcache-0.4.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7c2d1fa3201efaf55d730400d945b5b3ab6e672e100ba0f9a409d950ab25d7db", size = 79534, upload-time = "2025-10-08T19:46:02.083Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/6b/db0d03d96726d995dc7171286c6ba9d8d14251f37433890f88368951a44e/propcache-0.4.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1eb2994229cc8ce7fe9b3db88f5465f5fd8651672840b2e426b88cdb1a30aac8", size = 45526, upload-time = "2025-10-08T19:46:03.884Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c3/82728404aea669e1600f304f2609cde9e665c18df5a11cdd57ed73c1dceb/propcache-0.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:66c1f011f45a3b33d7bcb22daed4b29c0c9e2224758b6be00686731e1b46f925", size = 47263, upload-time = "2025-10-08T19:46:05.405Z" },
+    { url = "https://files.pythonhosted.org/packages/df/1b/39313ddad2bf9187a1432654c38249bab4562ef535ef07f5eb6eb04d0b1b/propcache-0.4.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9a52009f2adffe195d0b605c25ec929d26b36ef986ba85244891dee3b294df21", size = 201012, upload-time = "2025-10-08T19:46:07.165Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/01/f1d0b57d136f294a142acf97f4ed58c8e5b974c21e543000968357115011/propcache-0.4.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5d4e2366a9c7b837555cf02fb9be2e3167d333aff716332ef1b7c3a142ec40c5", size = 209491, upload-time = "2025-10-08T19:46:08.909Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/c8/038d909c61c5bb039070b3fb02ad5cccdb1dde0d714792e251cdb17c9c05/propcache-0.4.1-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9d2b6caef873b4f09e26ea7e33d65f42b944837563a47a94719cc3544319a0db", size = 215319, upload-time = "2025-10-08T19:46:10.7Z" },
+    { url = "https://files.pythonhosted.org/packages/08/57/8c87e93142b2c1fa2408e45695205a7ba05fb5db458c0bf5c06ba0e09ea6/propcache-0.4.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2b16ec437a8c8a965ecf95739448dd938b5c7f56e67ea009f4300d8df05f32b7", size = 196856, upload-time = "2025-10-08T19:46:12.003Z" },
+    { url = "https://files.pythonhosted.org/packages/42/df/5615fec76aa561987a534759b3686008a288e73107faa49a8ae5795a9f7a/propcache-0.4.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:296f4c8ed03ca7476813fe666c9ea97869a8d7aec972618671b33a38a5182ef4", size = 193241, upload-time = "2025-10-08T19:46:13.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/21/62949eb3a7a54afe8327011c90aca7e03547787a88fb8bd9726806482fea/propcache-0.4.1-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:1f0978529a418ebd1f49dad413a2b68af33f85d5c5ca5c6ca2a3bed375a7ac60", size = 190552, upload-time = "2025-10-08T19:46:14.938Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ee/ab4d727dd70806e5b4de96a798ae7ac6e4d42516f030ee60522474b6b332/propcache-0.4.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:fd138803047fb4c062b1c1dd95462f5209456bfab55c734458f15d11da288f8f", size = 200113, upload-time = "2025-10-08T19:46:16.695Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/0b/38b46208e6711b016aa8966a3ac793eee0d05c7159d8342aa27fc0bc365e/propcache-0.4.1-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:8c9b3cbe4584636d72ff556d9036e0c9317fa27b3ac1f0f558e7e84d1c9c5900", size = 200778, upload-time = "2025-10-08T19:46:18.023Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/81/5abec54355ed344476bee711e9f04815d4b00a311ab0535599204eecc257/propcache-0.4.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f93243fdc5657247533273ac4f86ae106cc6445a0efacb9a1bfe982fcfefd90c", size = 193047, upload-time = "2025-10-08T19:46:19.449Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/b6/1f237c04e32063cb034acd5f6ef34ef3a394f75502e72703545631ab1ef6/propcache-0.4.1-cp310-cp310-win32.whl", hash = "sha256:a0ee98db9c5f80785b266eb805016e36058ac72c51a064040f2bc43b61101cdb", size = 38093, upload-time = "2025-10-08T19:46:20.643Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/67/354aac4e0603a15f76439caf0427781bcd6797f370377f75a642133bc954/propcache-0.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:1cdb7988c4e5ac7f6d175a28a9aa0c94cb6f2ebe52756a3c0cda98d2809a9e37", size = 41638, upload-time = "2025-10-08T19:46:21.935Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/e1/74e55b9fd1a4c209ff1a9a824bf6c8b3d1fc5a1ac3eabe23462637466785/propcache-0.4.1-cp310-cp310-win_arm64.whl", hash = "sha256:d82ad62b19645419fe79dd63b3f9253e15b30e955c0170e5cebc350c1844e581", size = 38229, upload-time = "2025-10-08T19:46:23.368Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d4/4e2c9aaf7ac2242b9358f98dccd8f90f2605402f5afeff6c578682c2c491/propcache-0.4.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:60a8fda9644b7dfd5dece8c61d8a85e271cb958075bfc4e01083c148b61a7caf", size = 80208, upload-time = "2025-10-08T19:46:24.597Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/21/d7b68e911f9c8e18e4ae43bdbc1e1e9bbd971f8866eb81608947b6f585ff/propcache-0.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c30b53e7e6bda1d547cabb47c825f3843a0a1a42b0496087bb58d8fedf9f41b5", size = 45777, upload-time = "2025-10-08T19:46:25.733Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/1d/11605e99ac8ea9435651ee71ab4cb4bf03f0949586246476a25aadfec54a/propcache-0.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6918ecbd897443087a3b7cd978d56546a812517dcaaca51b49526720571fa93e", size = 47647, upload-time = "2025-10-08T19:46:27.304Z" },
+    { url = "https://files.pythonhosted.org/packages/58/1a/3c62c127a8466c9c843bccb503d40a273e5cc69838805f322e2826509e0d/propcache-0.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3d902a36df4e5989763425a8ab9e98cd8ad5c52c823b34ee7ef307fd50582566", size = 214929, upload-time = "2025-10-08T19:46:28.62Z" },
+    { url = "https://files.pythonhosted.org/packages/56/b9/8fa98f850960b367c4b8fe0592e7fc341daa7a9462e925228f10a60cf74f/propcache-0.4.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a9695397f85973bb40427dedddf70d8dc4a44b22f1650dd4af9eedf443d45165", size = 221778, upload-time = "2025-10-08T19:46:30.358Z" },
+    { url = "https://files.pythonhosted.org/packages/46/a6/0ab4f660eb59649d14b3d3d65c439421cf2f87fe5dd68591cbe3c1e78a89/propcache-0.4.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2bb07ffd7eaad486576430c89f9b215f9e4be68c4866a96e97db9e97fead85dc", size = 228144, upload-time = "2025-10-08T19:46:32.607Z" },
+    { url = "https://files.pythonhosted.org/packages/52/6a/57f43e054fb3d3a56ac9fc532bc684fc6169a26c75c353e65425b3e56eef/propcache-0.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fd6f30fdcf9ae2a70abd34da54f18da086160e4d7d9251f81f3da0ff84fc5a48", size = 210030, upload-time = "2025-10-08T19:46:33.969Z" },
+    { url = "https://files.pythonhosted.org/packages/40/e2/27e6feebb5f6b8408fa29f5efbb765cd54c153ac77314d27e457a3e993b7/propcache-0.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:fc38cba02d1acba4e2869eef1a57a43dfbd3d49a59bf90dda7444ec2be6a5570", size = 208252, upload-time = "2025-10-08T19:46:35.309Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/f8/91c27b22ccda1dbc7967f921c42825564fa5336a01ecd72eb78a9f4f53c2/propcache-0.4.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:67fad6162281e80e882fb3ec355398cf72864a54069d060321f6cd0ade95fe85", size = 202064, upload-time = "2025-10-08T19:46:36.993Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/26/7f00bd6bd1adba5aafe5f4a66390f243acab58eab24ff1a08bebb2ef9d40/propcache-0.4.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f10207adf04d08bec185bae14d9606a1444715bc99180f9331c9c02093e1959e", size = 212429, upload-time = "2025-10-08T19:46:38.398Z" },
+    { url = "https://files.pythonhosted.org/packages/84/89/fd108ba7815c1117ddca79c228f3f8a15fc82a73bca8b142eb5de13b2785/propcache-0.4.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:e9b0d8d0845bbc4cfcdcbcdbf5086886bc8157aa963c31c777ceff7846c77757", size = 216727, upload-time = "2025-10-08T19:46:39.732Z" },
+    { url = "https://files.pythonhosted.org/packages/79/37/3ec3f7e3173e73f1d600495d8b545b53802cbf35506e5732dd8578db3724/propcache-0.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:981333cb2f4c1896a12f4ab92a9cc8f09ea664e9b7dbdc4eff74627af3a11c0f", size = 205097, upload-time = "2025-10-08T19:46:41.025Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b0/b2631c19793f869d35f47d5a3a56fb19e9160d3c119f15ac7344fc3ccae7/propcache-0.4.1-cp311-cp311-win32.whl", hash = "sha256:f1d2f90aeec838a52f1c1a32fe9a619fefd5e411721a9117fbf82aea638fe8a1", size = 38084, upload-time = "2025-10-08T19:46:42.693Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/78/6cce448e2098e9f3bfc91bb877f06aa24b6ccace872e39c53b2f707c4648/propcache-0.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:364426a62660f3f699949ac8c621aad6977be7126c5807ce48c0aeb8e7333ea6", size = 41637, upload-time = "2025-10-08T19:46:43.778Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/e9/754f180cccd7f51a39913782c74717c581b9cc8177ad0e949f4d51812383/propcache-0.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:e53f3a38d3510c11953f3e6a33f205c6d1b001129f972805ca9b42fc308bc239", size = 38064, upload-time = "2025-10-08T19:46:44.872Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/0f/f17b1b2b221d5ca28b4b876e8bb046ac40466513960646bda8e1853cdfa2/propcache-0.4.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e153e9cd40cc8945138822807139367f256f89c6810c2634a4f6902b52d3b4e2", size = 80061, upload-time = "2025-10-08T19:46:46.075Z" },
+    { url = "https://files.pythonhosted.org/packages/76/47/8ccf75935f51448ba9a16a71b783eb7ef6b9ee60f5d14c7f8a8a79fbeed7/propcache-0.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:cd547953428f7abb73c5ad82cbb32109566204260d98e41e5dfdc682eb7f8403", size = 46037, upload-time = "2025-10-08T19:46:47.23Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/b6/5c9a0e42df4d00bfb4a3cbbe5cf9f54260300c88a0e9af1f47ca5ce17ac0/propcache-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f048da1b4f243fc44f205dfd320933a951b8d89e0afd4c7cacc762a8b9165207", size = 47324, upload-time = "2025-10-08T19:46:48.384Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/d3/6c7ee328b39a81ee877c962469f1e795f9db87f925251efeb0545e0020d0/propcache-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ec17c65562a827bba85e3872ead335f95405ea1674860d96483a02f5c698fa72", size = 225505, upload-time = "2025-10-08T19:46:50.055Z" },
+    { url = "https://files.pythonhosted.org/packages/01/5d/1c53f4563490b1d06a684742cc6076ef944bc6457df6051b7d1a877c057b/propcache-0.4.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:405aac25c6394ef275dee4c709be43745d36674b223ba4eb7144bf4d691b7367", size = 230242, upload-time = "2025-10-08T19:46:51.815Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e1/ce4620633b0e2422207c3cb774a0ee61cac13abc6217763a7b9e2e3f4a12/propcache-0.4.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0013cb6f8dde4b2a2f66903b8ba740bdfe378c943c4377a200551ceb27f379e4", size = 238474, upload-time = "2025-10-08T19:46:53.208Z" },
+    { url = "https://files.pythonhosted.org/packages/46/4b/3aae6835b8e5f44ea6a68348ad90f78134047b503765087be2f9912140ea/propcache-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15932ab57837c3368b024473a525e25d316d8353016e7cc0e5ba9eb343fbb1cf", size = 221575, upload-time = "2025-10-08T19:46:54.511Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/a5/8a5e8678bcc9d3a1a15b9a29165640d64762d424a16af543f00629c87338/propcache-0.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:031dce78b9dc099f4c29785d9cf5577a3faf9ebf74ecbd3c856a7b92768c3df3", size = 216736, upload-time = "2025-10-08T19:46:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/63/b7b215eddeac83ca1c6b934f89d09a625aa9ee4ba158338854c87210cc36/propcache-0.4.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:ab08df6c9a035bee56e31af99be621526bd237bea9f32def431c656b29e41778", size = 213019, upload-time = "2025-10-08T19:46:57.595Z" },
+    { url = "https://files.pythonhosted.org/packages/57/74/f580099a58c8af587cac7ba19ee7cb418506342fbbe2d4a4401661cca886/propcache-0.4.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4d7af63f9f93fe593afbf104c21b3b15868efb2c21d07d8732c0c4287e66b6a6", size = 220376, upload-time = "2025-10-08T19:46:59.067Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ee/542f1313aff7eaf19c2bb758c5d0560d2683dac001a1c96d0774af799843/propcache-0.4.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:cfc27c945f422e8b5071b6e93169679e4eb5bf73bbcbf1ba3ae3a83d2f78ebd9", size = 226988, upload-time = "2025-10-08T19:47:00.544Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/18/9c6b015dd9c6930f6ce2229e1f02fb35298b847f2087ea2b436a5bfa7287/propcache-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:35c3277624a080cc6ec6f847cbbbb5b49affa3598c4535a0a4682a697aaa5c75", size = 215615, upload-time = "2025-10-08T19:47:01.968Z" },
+    { url = "https://files.pythonhosted.org/packages/80/9e/e7b85720b98c45a45e1fca6a177024934dc9bc5f4d5dd04207f216fc33ed/propcache-0.4.1-cp312-cp312-win32.whl", hash = "sha256:671538c2262dadb5ba6395e26c1731e1d52534bfe9ae56d0b5573ce539266aa8", size = 38066, upload-time = "2025-10-08T19:47:03.503Z" },
+    { url = "https://files.pythonhosted.org/packages/54/09/d19cff2a5aaac632ec8fc03737b223597b1e347416934c1b3a7df079784c/propcache-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:cb2d222e72399fcf5890d1d5cc1060857b9b236adff2792ff48ca2dfd46c81db", size = 41655, upload-time = "2025-10-08T19:47:04.973Z" },
+    { url = "https://files.pythonhosted.org/packages/68/ab/6b5c191bb5de08036a8c697b265d4ca76148efb10fa162f14af14fb5f076/propcache-0.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:204483131fb222bdaaeeea9f9e6c6ed0cac32731f75dfc1d4a567fc1926477c1", size = 37789, upload-time = "2025-10-08T19:47:06.077Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/5a/bc7b4a4ef808fa59a816c17b20c4bef6884daebbdf627ff2a161da67da19/propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237", size = 13305, upload-time = "2025-10-08T19:49:00.792Z" },
+]
+
+[[package]]
+name = "pyaes"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/66/2c17bae31c906613795711fc78045c285048168919ace2220daa372c7d72/pyaes-1.6.1.tar.gz", hash = "sha256:02c1b1405c38d3c370b085fb952dd8bea3fadcee6411ad99f312cc129c536d8f", size = 28536, upload-time = "2017-09-20T21:17:54.23Z" }
+
+[[package]]
+name = "pyasn1"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/b6/6e630dff89739fcd427e3f72b3d905ce0acb85a45d4ec3e2678718a3487f/pyasn1-0.6.2.tar.gz", hash = "sha256:9b59a2b25ba7e4f8197db7686c09fb33e658b98339fadb826e9512629017833b", size = 146586, upload-time = "2026-01-16T18:04:18.534Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/b5/a96872e5184f354da9c84ae119971a0a4c221fe9b27a4d94bd43f2596727/pyasn1-0.6.2-py3-none-any.whl", hash = "sha256:1eb26d860996a18e9b6ed05e7aae0e9fc21619fcee6af91cca9bad4fbea224bf", size = 83371, upload-time = "2026-01-16T18:04:17.174Z" },
+]
+
+[[package]]
+name = "pydub"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/9a/e6bca0eed82db26562c73b5076539a4a08d3cffd19c3cc5913a3e61145fd/pydub-0.25.1.tar.gz", hash = "sha256:980a33ce9949cab2a569606b65674d748ecbca4f0796887fd6f46173a7b0d30f", size = 38326, upload-time = "2021-03-10T02:09:54.659Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/53/d78dc063216e62fc55f6b2eebb447f6a4b0a59f55c8406376f76bf959b08/pydub-0.25.1-py2.py3-none-any.whl", hash = "sha256:65617e33033874b59d87db603aa1ed450633288aefead953b30bded59cb599a6", size = 32327, upload-time = "2021-03-10T02:09:53.503Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.32.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "rsa"
+version = "4.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
+]
+
+[[package]]
+name = "telekit"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "cryptg" },
+    { name = "openai" },
+    { name = "pydub" },
+    { name = "python-dotenv" },
+    { name = "telethon" },
+    { name = "typer" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "cryptg", specifier = "==0.5.2" },
+    { name = "openai", specifier = "==0.27.8" },
+    { name = "pydub", specifier = ">=0.25.1,<0.26" },
+    { name = "python-dotenv", specifier = ">=1.0,<2.0" },
+    { name = "telethon", specifier = "==1.29.2" },
+    { name = "typer", specifier = "==0.9.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.3,<9" }]
+
+[[package]]
+name = "telethon"
+version = "1.29.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyaes" },
+    { name = "rsa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/d9/c109b7cb8962f0ee4ae29ccf51480e9db1a3c78abbb151e40af713aa0eac/Telethon-1.29.2.tar.gz", hash = "sha256:c34885c9435864fbd5e379700b7c022571c2b6b6c5dc9beb5ceac5699aa96c4a", size = 548742, upload-time = "2023-07-24T15:26:11.338Z" }
+
+[[package]]
+name = "tomli"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/30/31573e9457673ab10aa432461bee537ce6cef177667deca369efb79df071/tomli-2.4.0.tar.gz", hash = "sha256:aa89c3f6c277dd275d8e243ad24f3b5e701491a860d5121f2cdd399fbb31fc9c", size = 17477, upload-time = "2026-01-11T11:22:38.165Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/d9/3dc2289e1f3b32eb19b9785b6a006b28ee99acb37d1d47f78d4c10e28bf8/tomli-2.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b5ef256a3fd497d4973c11bf142e9ed78b150d36f5773f1ca6088c230ffc5867", size = 153663, upload-time = "2026-01-11T11:21:45.27Z" },
+    { url = "https://files.pythonhosted.org/packages/51/32/ef9f6845e6b9ca392cd3f64f9ec185cc6f09f0a2df3db08cbe8809d1d435/tomli-2.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5572e41282d5268eb09a697c89a7bee84fae66511f87533a6f88bd2f7b652da9", size = 148469, upload-time = "2026-01-11T11:21:46.873Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/c2/506e44cce89a8b1b1e047d64bd495c22c9f71f21e05f380f1a950dd9c217/tomli-2.4.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:551e321c6ba03b55676970b47cb1b73f14a0a4dce6a3e1a9458fd6d921d72e95", size = 236039, upload-time = "2026-01-11T11:21:48.503Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/40/e1b65986dbc861b7e986e8ec394598187fa8aee85b1650b01dd925ca0be8/tomli-2.4.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e3f639a7a8f10069d0e15408c0b96a2a828cfdec6fca05296ebcdcc28ca7c76", size = 243007, upload-time = "2026-01-11T11:21:49.456Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6f/6e39ce66b58a5b7ae572a0f4352ff40c71e8573633deda43f6a379d56b3e/tomli-2.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1b168f2731796b045128c45982d3a4874057626da0e2ef1fdd722848b741361d", size = 240875, upload-time = "2026-01-11T11:21:50.755Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ad/cb089cb190487caa80204d503c7fd0f4d443f90b95cf4ef5cf5aa0f439b0/tomli-2.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:133e93646ec4300d651839d382d63edff11d8978be23da4cc106f5a18b7d0576", size = 246271, upload-time = "2026-01-11T11:21:51.81Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/63/69125220e47fd7a3a27fd0de0c6398c89432fec41bc739823bcc66506af6/tomli-2.4.0-cp311-cp311-win32.whl", hash = "sha256:b6c78bdf37764092d369722d9946cb65b8767bfa4110f902a1b2542d8d173c8a", size = 96770, upload-time = "2026-01-11T11:21:52.647Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/0d/a22bb6c83f83386b0008425a6cd1fa1c14b5f3dd4bad05e98cf3dbbf4a64/tomli-2.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:d3d1654e11d724760cdb37a3d7691f0be9db5fbdaef59c9f532aabf87006dbaa", size = 107626, upload-time = "2026-01-11T11:21:53.459Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/6d/77be674a3485e75cacbf2ddba2b146911477bd887dda9d8c9dfb2f15e871/tomli-2.4.0-cp311-cp311-win_arm64.whl", hash = "sha256:cae9c19ed12d4e8f3ebf46d1a75090e4c0dc16271c5bce1c833ac168f08fb614", size = 94842, upload-time = "2026-01-11T11:21:54.831Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/43/7389a1869f2f26dba52404e1ef13b4784b6b37dac93bac53457e3ff24ca3/tomli-2.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:920b1de295e72887bafa3ad9f7a792f811847d57ea6b1215154030cf131f16b1", size = 154894, upload-time = "2026-01-11T11:21:56.07Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/05/2f9bf110b5294132b2edf13fe6ca6ae456204f3d749f623307cbb7a946f2/tomli-2.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7d6d9a4aee98fac3eab4952ad1d73aee87359452d1c086b5ceb43ed02ddb16b8", size = 149053, upload-time = "2026-01-11T11:21:57.467Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/41/1eda3ca1abc6f6154a8db4d714a4d35c4ad90adc0bcf700657291593fbf3/tomli-2.4.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:36b9d05b51e65b254ea6c2585b59d2c4cb91c8a3d91d0ed0f17591a29aaea54a", size = 243481, upload-time = "2026-01-11T11:21:58.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/6d/02ff5ab6c8868b41e7d4b987ce2b5f6a51d3335a70aa144edd999e055a01/tomli-2.4.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c8a885b370751837c029ef9bc014f27d80840e48bac415f3412e6593bbc18c1", size = 251720, upload-time = "2026-01-11T11:22:00.178Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/57/0405c59a909c45d5b6f146107c6d997825aa87568b042042f7a9c0afed34/tomli-2.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8768715ffc41f0008abe25d808c20c3d990f42b6e2e58305d5da280ae7d1fa3b", size = 247014, upload-time = "2026-01-11T11:22:01.238Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/0e/2e37568edd944b4165735687cbaf2fe3648129e440c26d02223672ee0630/tomli-2.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7b438885858efd5be02a9a133caf5812b8776ee0c969fea02c45e8e3f296ba51", size = 251820, upload-time = "2026-01-11T11:22:02.727Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/1c/ee3b707fdac82aeeb92d1a113f803cf6d0f37bdca0849cb489553e1f417a/tomli-2.4.0-cp312-cp312-win32.whl", hash = "sha256:0408e3de5ec77cc7f81960c362543cbbd91ef883e3138e81b729fc3eea5b9729", size = 97712, upload-time = "2026-01-11T11:22:03.777Z" },
+    { url = "https://files.pythonhosted.org/packages/69/13/c07a9177d0b3bab7913299b9278845fc6eaaca14a02667c6be0b0a2270c8/tomli-2.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:685306e2cc7da35be4ee914fd34ab801a6acacb061b6a7abca922aaf9ad368da", size = 108296, upload-time = "2026-01-11T11:22:04.86Z" },
+    { url = "https://files.pythonhosted.org/packages/18/27/e267a60bbeeee343bcc279bb9e8fbed0cbe224bc7b2a3dc2975f22809a09/tomli-2.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:5aa48d7c2356055feef06a43611fc401a07337d5b006be13a30f6c58f869e3c3", size = 94553, upload-time = "2026-01-11T11:22:05.854Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/49/39f10d0f75886439ab3dac889f14f8ad511982a754e382c9b6ca895b29e9/typer-0.9.0.tar.gz", hash = "sha256:50922fd79aea2f4751a8e0408ff10d2662bd0c8bbfa84755a699f3bada2978b2", size = 273985, upload-time = "2023-05-02T05:20:57.63Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/0e/c68adf10adda05f28a6ed7b9f4cd7b8e07f641b44af88ba72d9c89e4de7a/typer-0.9.0-py3-none-any.whl", hash = "sha256:5d96d986a21493606a358cae4461bd8cdf83cbf33a5aa950ae629ca3b51467ee", size = 45861, upload-time = "2023-05-02T05:20:55.675Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "yarl"
+version = "1.23.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "multidict" },
+    { name = "propcache" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/6e/beb1beec874a72f23815c1434518bfc4ed2175065173fb138c3705f658d4/yarl-1.23.0.tar.gz", hash = "sha256:53b1ea6ca88ebd4420379c330aea57e258408dd0df9af0992e5de2078dc9f5d5", size = 194676, upload-time = "2026-03-01T22:07:53.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/0d/9cc638702f6fc3c7a3685bcc8cf2a9ed7d6206e932a49f5242658047ef51/yarl-1.23.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cff6d44cb13d39db2663a22b22305d10855efa0fa8015ddeacc40bc59b9d8107", size = 123764, upload-time = "2026-03-01T22:04:09.7Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/35/5a553687c5793df5429cd1db45909d4f3af7eee90014888c208d086a44f0/yarl-1.23.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e4c53f8347cd4200f0d70a48ad059cabaf24f5adc6ba08622a23423bc7efa10d", size = 86282, upload-time = "2026-03-01T22:04:11.892Z" },
+    { url = "https://files.pythonhosted.org/packages/68/2e/c5a2234238f8ce37a8312b52801ee74117f576b1539eec8404a480434acc/yarl-1.23.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2a6940a074fb3c48356ed0158a3ca5699c955ee4185b4d7d619be3c327143e05", size = 86053, upload-time = "2026-03-01T22:04:13.292Z" },
+    { url = "https://files.pythonhosted.org/packages/74/3f/bbd8ff36fb038622797ffbaf7db314918bb4d76f1cc8a4f9ca7a55fe5195/yarl-1.23.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ed5f69ce7be7902e5c70ea19eb72d20abf7d725ab5d49777d696e32d4fc1811d", size = 99395, upload-time = "2026-03-01T22:04:15.133Z" },
+    { url = "https://files.pythonhosted.org/packages/77/04/9516bc4e269d2a3ec9c6779fcdeac51ce5b3a9b0156f06ac7152e5bba864/yarl-1.23.0-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:389871e65468400d6283c0308e791a640b5ab5c83bcee02a2f51295f95e09748", size = 92143, upload-time = "2026-03-01T22:04:16.829Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/63/88802d1f6b1cb1fc67d67a58cd0cf8a1790de4ce7946e434240f1d60ab4a/yarl-1.23.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:dda608c88cf709b1d406bdfcd84d8d63cff7c9e577a403c6108ce8ce9dcc8764", size = 107643, upload-time = "2026-03-01T22:04:18.519Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/db/4f9b838f4d8bdd6f0f385aed8bbf21c71ed11a0b9983305c302cbd557815/yarl-1.23.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8c4fe09e0780c6c3bf2b7d4af02ee2394439d11a523bbcf095cf4747c2932007", size = 108700, upload-time = "2026-03-01T22:04:20.373Z" },
+    { url = "https://files.pythonhosted.org/packages/50/12/95a1d33f04a79c402664070d43b8b9f72dc18914e135b345b611b0b1f8cc/yarl-1.23.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:31c9921eb8bd12633b41ad27686bbb0b1a2a9b8452bfdf221e34f311e9942ed4", size = 102769, upload-time = "2026-03-01T22:04:23.055Z" },
+    { url = "https://files.pythonhosted.org/packages/86/65/91a0285f51321369fd1a8308aa19207520c5f0587772cfc2e03fc2467e90/yarl-1.23.0-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5f10fd85e4b75967468af655228fbfd212bdf66db1c0d135065ce288982eda26", size = 101114, upload-time = "2026-03-01T22:04:25.031Z" },
+    { url = "https://files.pythonhosted.org/packages/58/80/c7c8244fc3e5bc483dc71a09560f43b619fab29301a0f0a8f936e42865c7/yarl-1.23.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:dbf507e9ef5688bada447a24d68b4b58dd389ba93b7afc065a2ba892bea54769", size = 98883, upload-time = "2026-03-01T22:04:27.281Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e7/71ca9cc9ca79c0b7d491216177d1aed559d632947b8ffb0ee60f7d8b23e3/yarl-1.23.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:85e9beda1f591bc73e77ea1c51965c68e98dafd0fec72cdd745f77d727466716", size = 94172, upload-time = "2026-03-01T22:04:28.554Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/3f/6c6c8a0fe29c26fb2db2e8d32195bb84ec1bfb8f1d32e7f73b787fcf349b/yarl-1.23.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:0e1fdaa14ef51366d7757b45bde294e95f6c8c049194e793eedb8387c86d5993", size = 107010, upload-time = "2026-03-01T22:04:30.385Z" },
+    { url = "https://files.pythonhosted.org/packages/56/38/12730c05e5ad40a76374d440ed8b0899729a96c250516d91c620a6e38fc2/yarl-1.23.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:75e3026ab649bf48f9a10c0134512638725b521340293f202a69b567518d94e0", size = 100285, upload-time = "2026-03-01T22:04:31.752Z" },
+    { url = "https://files.pythonhosted.org/packages/34/92/6a7be9239f2347234e027284e7a5f74b1140cc86575e7b469d13fba1ebfe/yarl-1.23.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:80e6d33a3d42a7549b409f199857b4fb54e2103fc44fb87605b6663b7a7ff750", size = 108230, upload-time = "2026-03-01T22:04:33.844Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/81/4aebccfa9376bd98b9d8bfad20621a57d3e8cfc5b8631c1fa5f62cdd03f4/yarl-1.23.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5ec2f42d41ccbd5df0270d7df31618a8ee267bfa50997f5d720ddba86c4a83a6", size = 103008, upload-time = "2026-03-01T22:04:35.856Z" },
+    { url = "https://files.pythonhosted.org/packages/38/0f/0b4e3edcec794a86b853b0c6396c0a888d72dfce19b2d88c02ac289fb6c1/yarl-1.23.0-cp310-cp310-win32.whl", hash = "sha256:debe9c4f41c32990771be5c22b56f810659f9ddf3d63f67abfdcaa2c6c9c5c1d", size = 83073, upload-time = "2026-03-01T22:04:38.268Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/71/ad95c33da18897e4c636528bbc24a1dd23fe16797de8bc4ec667b8db0ba4/yarl-1.23.0-cp310-cp310-win_amd64.whl", hash = "sha256:ab5f043cb8a2d71c981c09c510da013bc79fd661f5c60139f00dd3c3cc4f2ffb", size = 87328, upload-time = "2026-03-01T22:04:39.558Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/14/dfa369523c79bccf9c9c746b0a63eb31f65db9418ac01275f7950962e504/yarl-1.23.0-cp310-cp310-win_arm64.whl", hash = "sha256:263cd4f47159c09b8b685890af949195b51d1aa82ba451c5847ca9bc6413c220", size = 82463, upload-time = "2026-03-01T22:04:41.454Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/aa/60da938b8f0997ba3a911263c40d82b6f645a67902a490b46f3355e10fae/yarl-1.23.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:b35d13d549077713e4414f927cdc388d62e543987c572baee613bf82f11a4b99", size = 123641, upload-time = "2026-03-01T22:04:42.841Z" },
+    { url = "https://files.pythonhosted.org/packages/24/84/e237607faf4e099dbb8a4f511cfd5efcb5f75918baad200ff7380635631b/yarl-1.23.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cbb0fef01f0c6b38cb0f39b1f78fc90b807e0e3c86a7ff3ce74ad77ce5c7880c", size = 86248, upload-time = "2026-03-01T22:04:44.757Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/0d/71ceabc14c146ba8ee3804ca7b3d42b1664c8440439de5214d366fec7d3a/yarl-1.23.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dc52310451fc7c629e13c4e061cbe2dd01684d91f2f8ee2821b083c58bd72432", size = 85988, upload-time = "2026-03-01T22:04:46.365Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/6c/4a90d59c572e46b270ca132aca66954f1175abd691f74c1ef4c6711828e2/yarl-1.23.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b2c6b50c7b0464165472b56b42d4c76a7b864597007d9c085e8b63e185cf4a7a", size = 100566, upload-time = "2026-03-01T22:04:47.639Z" },
+    { url = "https://files.pythonhosted.org/packages/49/fb/c438fb5108047e629f6282a371e6e91cf3f97ee087c4fb748a1f32ceef55/yarl-1.23.0-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:aafe5dcfda86c8af00386d7781d4c2181b5011b7be3f2add5e99899ea925df05", size = 92079, upload-time = "2026-03-01T22:04:48.925Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/13/d269aa1aed3e4f50a5a103f96327210cc5fa5dd2d50882778f13c7a14606/yarl-1.23.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9ee33b875f0b390564c1fb7bc528abf18c8ee6073b201c6ae8524aca778e2d83", size = 108741, upload-time = "2026-03-01T22:04:50.838Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/115b16f22c37ea4437d323e472945bea97301c8ec6089868fa560abab590/yarl-1.23.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4c41e021bc6d7affb3364dc1e1e5fa9582b470f283748784bd6ea0558f87f42c", size = 108099, upload-time = "2026-03-01T22:04:52.499Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/64/c53487d9f4968045b8afa51aed7ca44f58b2589e772f32745f3744476c82/yarl-1.23.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:99c8a9ed30f4164bc4c14b37a90208836cbf50d4ce2a57c71d0f52c7fb4f7598", size = 102678, upload-time = "2026-03-01T22:04:55.176Z" },
+    { url = "https://files.pythonhosted.org/packages/85/59/cd98e556fbb2bf8fab29c1a722f67ad45c5f3447cac798ab85620d1e70af/yarl-1.23.0-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f2af5c81a1f124609d5f33507082fc3f739959d4719b56877ab1ee7e7b3d602b", size = 100803, upload-time = "2026-03-01T22:04:56.588Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c0/b39770b56d4a9f0bb5f77e2f1763cd2d75cc2f6c0131e3b4c360348fcd65/yarl-1.23.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6b41389c19b07c760c7e427a3462e8ab83c4bb087d127f0e854c706ce1b9215c", size = 100163, upload-time = "2026-03-01T22:04:58.492Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/64/6980f99ab00e1f0ff67cb84766c93d595b067eed07439cfccfc8fb28c1a6/yarl-1.23.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:1dc702e42d0684f42d6519c8d581e49c96cefaaab16691f03566d30658ee8788", size = 93859, upload-time = "2026-03-01T22:05:00.268Z" },
+    { url = "https://files.pythonhosted.org/packages/38/69/912e6c5e146793e5d4b5fe39ff5b00f4d22463dfd5a162bec565ac757673/yarl-1.23.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:0e40111274f340d32ebcc0a5668d54d2b552a6cca84c9475859d364b380e3222", size = 108202, upload-time = "2026-03-01T22:05:02.273Z" },
+    { url = "https://files.pythonhosted.org/packages/59/97/35ca6767524687ad64e5f5c31ad54bc76d585585a9fcb40f649e7e82ffed/yarl-1.23.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:4764a6a7588561a9aef92f65bda2c4fb58fe7c675c0883862e6df97559de0bfb", size = 99866, upload-time = "2026-03-01T22:05:03.597Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/1c/1a3387ee6d73589f6f2a220ae06f2984f6c20b40c734989b0a44f5987308/yarl-1.23.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:03214408cfa590df47728b84c679ae4ef00be2428e11630277be0727eba2d7cc", size = 107852, upload-time = "2026-03-01T22:05:04.986Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/b8/35c0750fcd5a3f781058bfd954515dd4b1eab45e218cbb85cf11132215f1/yarl-1.23.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:170e26584b060879e29fac213e4228ef063f39128723807a312e5c7fec28eff2", size = 102919, upload-time = "2026-03-01T22:05:06.397Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/1c/9a1979aec4a81896d597bcb2177827f2dbee3f5b7cc48b2d0dadb644b41d/yarl-1.23.0-cp311-cp311-win32.whl", hash = "sha256:51430653db848d258336cfa0244427b17d12db63d42603a55f0d4546f50f25b5", size = 82602, upload-time = "2026-03-01T22:05:08.444Z" },
+    { url = "https://files.pythonhosted.org/packages/93/22/b85eca6fa2ad9491af48c973e4c8cf6b103a73dbb271fe3346949449fca0/yarl-1.23.0-cp311-cp311-win_amd64.whl", hash = "sha256:bf49a3ae946a87083ef3a34c8f677ae4243f5b824bfc4c69672e72b3d6719d46", size = 87461, upload-time = "2026-03-01T22:05:10.145Z" },
+    { url = "https://files.pythonhosted.org/packages/93/95/07e3553fe6f113e6864a20bdc53a78113cda3b9ced8784ee52a52c9f80d8/yarl-1.23.0-cp311-cp311-win_arm64.whl", hash = "sha256:b39cb32a6582750b6cc77bfb3c49c0f8760dc18dc96ec9fb55fbb0f04e08b928", size = 82336, upload-time = "2026-03-01T22:05:11.554Z" },
+    { url = "https://files.pythonhosted.org/packages/88/8a/94615bc31022f711add374097ad4144d569e95ff3c38d39215d07ac153a0/yarl-1.23.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1932b6b8bba8d0160a9d1078aae5838a66039e8832d41d2992daa9a3a08f7860", size = 124737, upload-time = "2026-03-01T22:05:12.897Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/6f/c6554045d59d64052698add01226bc867b52fe4a12373415d7991fdca95d/yarl-1.23.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:411225bae281f114067578891bc75534cfb3d92a3b4dfef7a6ca78ba354e6069", size = 87029, upload-time = "2026-03-01T22:05:14.376Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/725ecc166d53438bc88f76822ed4b1e3b10756e790bafd7b523fe97c322d/yarl-1.23.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:13a563739ae600a631c36ce096615fe307f131344588b0bc0daec108cdb47b25", size = 86310, upload-time = "2026-03-01T22:05:15.71Z" },
+    { url = "https://files.pythonhosted.org/packages/99/30/58260ed98e6ff7f90ba84442c1ddd758c9170d70327394a6227b310cd60f/yarl-1.23.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cbf44c5cb4a7633d078788e1b56387e3d3cf2b8139a3be38040b22d6c3221c8", size = 97587, upload-time = "2026-03-01T22:05:17.384Z" },
+    { url = "https://files.pythonhosted.org/packages/76/0a/8b08aac08b50682e65759f7f8dde98ae8168f72487e7357a5d684c581ef9/yarl-1.23.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:53ad387048f6f09a8969631e4de3f1bf70c50e93545d64af4f751b2498755072", size = 92528, upload-time = "2026-03-01T22:05:18.804Z" },
+    { url = "https://files.pythonhosted.org/packages/52/07/0b7179101fe5f8385ec6c6bb5d0cb9f76bd9fb4a769591ab6fb5cdbfc69a/yarl-1.23.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4a59ba56f340334766f3a4442e0efd0af895fae9e2b204741ef885c446b3a1a8", size = 105339, upload-time = "2026-03-01T22:05:20.235Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/8a/36d82869ab5ec829ca8574dfcb92b51286fcfb1e9c7a73659616362dc880/yarl-1.23.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:803a3c3ce4acc62eaf01eaca1208dcf0783025ef27572c3336502b9c232005e7", size = 105061, upload-time = "2026-03-01T22:05:22.268Z" },
+    { url = "https://files.pythonhosted.org/packages/66/3e/868e5c3364b6cee19ff3e1a122194fa4ce51def02c61023970442162859e/yarl-1.23.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a3d2bff8f37f8d0f96c7ec554d16945050d54462d6e95414babaa18bfafc7f51", size = 100132, upload-time = "2026-03-01T22:05:23.638Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/26/9c89acf82f08a52cb52d6d39454f8d18af15f9d386a23795389d1d423823/yarl-1.23.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c75eb09e8d55bceb4367e83496ff8ef2bc7ea6960efb38e978e8073ea59ecb67", size = 99289, upload-time = "2026-03-01T22:05:25.749Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/54/5b0db00d2cb056922356104468019c0a132e89c8d3ab67d8ede9f4483d2a/yarl-1.23.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:877b0738624280e34c55680d6054a307aa94f7d52fa0e3034a9cc6e790871da7", size = 96950, upload-time = "2026-03-01T22:05:27.318Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/40/10fa93811fd439341fad7e0718a86aca0de9548023bbb403668d6555acab/yarl-1.23.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b5405bb8f0e783a988172993cfc627e4d9d00432d6bbac65a923041edacf997d", size = 93960, upload-time = "2026-03-01T22:05:28.738Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/d2/8ae2e6cd77d0805f4526e30ec43b6f9a3dfc542d401ac4990d178e4bf0cf/yarl-1.23.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1c3a3598a832590c5a3ce56ab5576361b5688c12cb1d39429cf5dba30b510760", size = 104703, upload-time = "2026-03-01T22:05:30.438Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/0c/b3ceacf82c3fe21183ce35fa2acf5320af003d52bc1fcf5915077681142e/yarl-1.23.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:8419ebd326430d1cbb7efb5292330a2cf39114e82df5cc3d83c9a0d5ebeaf2f2", size = 98325, upload-time = "2026-03-01T22:05:31.835Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/e0/12900edd28bdab91a69bd2554b85ad7b151f64e8b521fe16f9ad2f56477a/yarl-1.23.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:be61f6fff406ca40e3b1d84716fde398fc08bc63dd96d15f3a14230a0973ed86", size = 105067, upload-time = "2026-03-01T22:05:33.358Z" },
+    { url = "https://files.pythonhosted.org/packages/15/61/74bb1182cf79c9bbe4eb6b1f14a57a22d7a0be5e9cedf8e2d5c2086474c3/yarl-1.23.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3ceb13c5c858d01321b5d9bb65e4cf37a92169ea470b70fec6f236b2c9dd7e34", size = 100285, upload-time = "2026-03-01T22:05:35.4Z" },
+    { url = "https://files.pythonhosted.org/packages/69/7f/cd5ef733f2550de6241bd8bd8c3febc78158b9d75f197d9c7baa113436af/yarl-1.23.0-cp312-cp312-win32.whl", hash = "sha256:fffc45637bcd6538de8b85f51e3df3223e4ad89bccbfca0481c08c7fc8b7ed7d", size = 82359, upload-time = "2026-03-01T22:05:36.811Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/be/25216a49daeeb7af2bec0db22d5e7df08ed1d7c9f65d78b14f3b74fd72fc/yarl-1.23.0-cp312-cp312-win_amd64.whl", hash = "sha256:f69f57305656a4852f2a7203efc661d8c042e6cc67f7acd97d8667fb448a426e", size = 87674, upload-time = "2026-03-01T22:05:38.171Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/35/aeab955d6c425b227d5b7247eafb24f2653fedc32f95373a001af5dfeb9e/yarl-1.23.0-cp312-cp312-win_arm64.whl", hash = "sha256:6e87a6e8735b44816e7db0b2fbc9686932df473c826b0d9743148432e10bb9b9", size = 81879, upload-time = "2026-03-01T22:05:40.006Z" },
+    { url = "https://files.pythonhosted.org/packages/69/68/c8739671f5699c7dc470580a4f821ef37c32c4cb0b047ce223a7f115757f/yarl-1.23.0-py3-none-any.whl", hash = "sha256:a2df6afe50dea8ae15fa34c9f824a3ee958d785fd5d089063d960bae1daa0a3f", size = 48288, upload-time = "2026-03-01T22:07:51.388Z" },
+]


### PR DESCRIPTION
## Summary

This PR fixes the current local/runtime setup problems in Telekit, makes transcription model selection configurable, improves long-transcript delivery, and documents the actual operator workflow.

It also adds repository guidance for future contributors via `AGENTS.md` and `PLANS.md`.

Closes #3

## What changed

- package Telekit as a real CLI with `pyproject.toml` and `uv` support
- centralize runtime/env resolution in `telekit_config.py`
- add a local `docker-compose.yml` that mirrors the server deployment shape
- make session, clients, data, and jobs paths configurable and repo-local by default
- add `--transcription-model` and `TELEKIT_TRANSCRIPTION_MODEL`
- support `whisper-1`, `gpt-4o-transcribe`, and `gpt-4o-mini-transcribe`
- normalize transcription responses so GPT transcription models work with the existing flow
- fix long-audio chunking to use real temp chunk files instead of passing in-memory segments directly
- change long transcript delivery to prefer inline chunked Telegram messages before falling back to `transcription.txt`
- add clearer startup/session logging during Telethon login flow
- rewrite README and `.env.example` to document:
  - local `uv` workflow
  - Docker workflow
  - Telegram trigger usage
  - current capabilities and limitations
- add tests for runtime config, CLI help, model selection, chunked transcription flow, and long transcript delivery
- add `AGENTS.md` and `PLANS.md` for repo-level contributor guidance

## Issue #3 resolution

Issue #3 was caused by the project having an inconsistent runtime contract:

- local `python app.py ...` usage did not match the Docker/runtime assumptions
- dependencies like `python-dotenv` and `pydub` were installed ad hoc in Docker but not declared consistently for local use
- session/data paths were effectively Docker-specific in parts of the code
- the project did not declare a supported Python range clearly

This PR resolves that by:

- declaring dependencies in `pyproject.toml`
- supporting `uv` as the primary local workflow
- keeping `requirements.txt` only as a compatibility shim
- moving path/env handling into a shared settings layer
- aligning Docker and local execution around the same `telekit` CLI
- documenting supported Python as `>=3.10,<3.13`

## Validation

Ran locally:

- `uv run pytest`
- `uv run telekit --help`
- `uv run telekit start-program --help`
- `docker compose build`
- `docker compose up -d`
- `docker compose logs --tail=200`
- `docker compose exec -T telekit python -c "from telekit_config import load_settings; print(load_settings().transcription_model)"`
- `docker compose down`

## Notes

- no secrets, `.env`, session files, or local Telegram/OpenAI data are included
- the local compose service/container is named `telekit`
- Docker startup was verified with an already-authorized session

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI to add/delete clients and start the program with selectable transcription model; configurable runtime defaults and paths; multiple transcription models and improved long-audio chunking with smarter delivery.

* **Bug Fixes**
  * More reliable transcript delivery for long/text-heavy outputs with edits, splits and fallbacks.

* **Documentation**
  * Major README overhaul, new agent guide and ExecPlan/PLANS documentation.

* **Tests**
  * Comprehensive tests for CLI, runtime config, transcription flows, and job handling.

* **Chores**
  * Packaging, .gitignore, env example, Docker packaging and runtime refinements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->